### PR TITLE
장바구니 Redux로 상태 관리 기능 추가, 옵션 없는 상품은 수량만 나오도록 수정

### DIFF
--- a/src/components/cart/CartComponent.jsx
+++ b/src/components/cart/CartComponent.jsx
@@ -1,32 +1,17 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { changeQty } from "../../store/cartSlice";
 
 const CartComponent = () => {
   const navigate = useNavigate();
 
-  const [cart, setCart] = useState([
-    {
-      id: 1,
-      brand: "HYGEE",
-      name: "보디 바디스크럽 285g",
-      price: 24000,
-      qty: 1,
-    },
-    {
-      id: 2,
-      brand: "HYGEE",
-      name: "수딩 알로에 진정 수분크림 120ml",
-      price: 42000,
-      qty: 1,
-    },
-    {
-      id: 3,
-      brand: "HYGEE",
-      name: "수분 진정 토너 500ml",
-      price: 45000,
-      qty: 1,
-    },
-  ]);
+  // cartSlice에 action을 전달할 dispatch 불러오기
+  const dispatch = useDispatch();
+
+  //store 전역 저장소에서 장바구니 내역 불러오기
+  const cart = useSelector((state) => state.cart);
+  // const [cart, setCart] = useState(cartState);
 
   const [selectedItems, setSelectedItems] = useState(
     cart.map((item) => item.id)
@@ -46,31 +31,33 @@ const CartComponent = () => {
     );
   };
 
-  const increaseQty = (id) => {
-    setCart((prev) =>
-      prev.map((i) => (i.id === id ? { ...i, qty: i.qty + 1 } : i))
-    );
-  };
+  // const increaseQty = (id) => {
+  //   setCart((prev) =>
+  //     prev.map((i) => (i.id === id ? { ...i, qty: i.qty + 1 } : i))
+  //   );
+  // };
 
-  const decreaseQty = (id) => {
-    setCart((prev) =>
-      prev.map((i) => (i.id === id && i.qty > 1 ? { ...i, qty: i.qty - 1 } : i))
-    );
+  // const decreaseQty = (id) => {
+  //   setCart((prev) =>
+  //     prev.map((i) => (i.id === id && i.qty > 1 ? { ...i, qty: i.qty - 1 } : i))
+  //   );
+  // };
+
+  const handleChangeQty = (id, delta) => {
+    dispatch(changeQty({ id, delta }));
   };
 
   const selectedCartItems = cart.filter((item) =>
     selectedItems.includes(item.id)
   );
 
-  const totalPrice = selectedCartItems.reduce(
-    (sum, item) => sum + item.price * item.qty,
-    0
-  );
+  const totalPrice = cart.reduce((sum, item) => sum + item.price * item.qty, 0);
 
   const shipping = totalPrice >= 20000 ? 0 : 2500;
 
   // ✅ 주문 페이지 이동 시 선택한 상품만 전달
   const handleOrderSelected = () => {
+    if (selectedCartItems.length === 0) return alert("상품을 선택해주세요");
     navigate("/order", { state: { items: selectedCartItems } });
   };
 
@@ -145,14 +132,14 @@ const CartComponent = () => {
                     <div className="flex items-center justify-center gap-2">
                       <button
                         className="w-6 h-6 border border-[#111111] rounded text-xs"
-                        onClick={() => decreaseQty(item.id)}
+                        onClick={() => handleChangeQty(item.id, -1)}
                       >
                         -
                       </button>
                       <span className="w-6 text-center">{item.qty}</span>
                       <button
                         className="w-6 h-6 border border-[#111111] rounded text-xs"
-                        onClick={() => increaseQty(item.id)}
+                        onClick={() => handleChangeQty(item.id, +1)}
                       >
                         +
                       </button>

--- a/src/components/product/detail/ProductDetailOptions.jsx
+++ b/src/components/product/detail/ProductDetailOptions.jsx
@@ -35,7 +35,7 @@ const ProductDetailOptions = ({ product, selectedItems, setSelectedItems }) => {
 
       {/* 드롭다운 리스트 */}
       {isOpen && (
-        <ul className="absolute left-0 w-full mt-1 max-h-60 overflow-y-auto bg-white border rounded-lg shadow-lg z-10">
+        <ul className="w-full mt-1 max-h-60 overflow-y-auto bg-white border rounded-lg shadow-lg">
           {product.options.map((o) => (
             <li
               key={o.id}

--- a/src/components/product/detail/ProductDetailQuantity.jsx
+++ b/src/components/product/detail/ProductDetailQuantity.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+const ProductDetailQuantity = ({ qty, setQty, price }) => {
+  const handleChangeQty = (delta) => {
+    setQty((prev) => Math.max(1, prev + delta));
+  };
+
+  return (
+    <div className="mt-4 border rounded-md bg-gray-50 p-4">
+      <div className="flex items-center justify-between">
+        {/* 왼쪽 : 수량 텍스트 */}
+        <div className="text-sm text-gray-700 font-medium">수량</div>
+
+        {/* 가운데 : 수량 조절 버튼 UI */}
+        <div className="flex items-center border rounded-md overflow-hidden">
+          <button
+            onClick={() => handleChangeQty(-1)}
+            className="w-9 h-9 flex justify-center items-center text-lg text-gray-600 border-r hover:bg-gray-100"
+          >
+            -
+          </button>
+          <span className="w-12 h-9 flex justify-center items-center text-sm text-gray-800 select-none">
+            {qty}
+          </span>
+          <button
+            onClick={() => handleChangeQty(+1)}
+            className="w-9 h-9 flex justify-center items-center text-lg text-gray-600 border-l hover:bg-gray-100"
+          >
+            +
+          </button>
+        </div>
+
+        {/* 오른쪽 : 계산된 가격 */}
+        <div className="text-sm font-semibold text-[#111111] whitespace-nowrap">
+          {(price * qty).toLocaleString()}원
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProductDetailQuantity;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,9 +2,13 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
+import { Provider } from "react-redux";
+import store from "./store/store.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </StrictMode>
 );

--- a/src/store/cartSlice.jsx
+++ b/src/store/cartSlice.jsx
@@ -1,0 +1,30 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const cartSlice = createSlice({
+  name: "cart",
+  initialState: [],
+  reducers: {
+    addItem: (state, action) => {
+      // action.payload = {id, name, qty, price ... }
+      const existing = state.find((item) => item.id === action.payload.id);
+      if (existing) {
+        existing.qty += action.payload.qty; // 같은 상품이면 수량 증가
+      } else {
+        state.push(action.payload); // 새로 담기
+      }
+    },
+    removeItem: (state, action) => {
+      return state.filter((item) => item.id !== action.payload);
+    },
+    changeQty: (state, action) => {
+      const { id, delta } = action.payload;
+      const item = state.find((item) => item.id === id);
+      if (item) {
+        item.qty = Math.max(1, item.qty + delta); // 최소 1개 유지
+      }
+    },
+  },
+});
+
+export const { addItem, removeItem, changeQty } = cartSlice.actions;
+export default cartSlice.reducer;

--- a/src/store/store.jsx
+++ b/src/store/store.jsx
@@ -1,0 +1,10 @@
+import { configureStore } from "@reduxjs/toolkit";
+import cartReducer from "./cartSlice";
+
+const store = configureStore({
+  reducer: {
+    cart: cartReducer,
+  },
+});
+
+export default store;


### PR DESCRIPTION
1. 장바구니를 전역으로 상태 관리하기 위해서 Redux 기능 추가
2. 옵션 없는 상품은 옵션창 제거하고 수량만 나오도록 수정
3. 상품 상세페이지에서 장바구니에 담기 버튼 누르면 장바구니에 담기고, 구매하기 버튼 누르면 구매페이지로 상품 데이터가 전달되도록 수정