### PR TITLE
[프론트] 고객센터 페이지 설계 및 기능 구현

### DIFF
--- a/src/components/helpcenter/NoticeForm.jsx
+++ b/src/components/helpcenter/NoticeForm.jsx
@@ -1,0 +1,89 @@
+import React, { useState } from "react";
+
+const noticeTypes = ["일반", "배송공지", "고객센터"];
+
+export default function NoticeForm({ mode, initialData, onSave, onCancel }) {
+  const [formData, setFormData] = useState(
+    initialData || {
+      title: "",
+      type: "일반",
+      content: "",
+    }
+  );
+
+  const handleSubmit = () => {
+    if (!formData.title.trim()) {
+      alert("제목을 입력해주세요.");
+      return;
+    }
+    if (!formData.content.trim()) {
+      alert("내용을 입력해주세요.");
+      return;
+    }
+    onSave(formData);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* 분류 */}
+      <div>
+        <label className="block text-sm font-medium mb-2">분류</label>
+        <select
+          value={formData.type}
+          onChange={(e) => setFormData({ ...formData, type: e.target.value })}
+          className="w-full max-w-xs border border-gray-300 rounded-sm px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        >
+          {noticeTypes.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* 제목 */}
+      <div>
+        <label className="block text-sm font-medium mb-2">제목</label>
+        <input
+          type="text"
+          value={formData.title}
+          onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+          placeholder="제목을 입력하세요"
+          className="w-full border border-gray-300 rounded-sm px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-black"
+        />
+      </div>
+
+      {/* 내용 */}
+      <div>
+        <label className="block text-sm font-medium mb-2">내용</label>
+        <textarea
+          value={formData.content}
+          onChange={(e) =>
+            setFormData({ ...formData, content: e.target.value })
+          }
+          placeholder="내용을 입력하세요"
+          rows={15}
+          className="w-full border border-gray-300 rounded-sm px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-black resize-none"
+        />
+      </div>
+
+      {/* 버튼 */}
+      <div className="flex gap-3 pt-4 border-t">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-6 py-2 border border-gray-300 rounded-sm text-sm hover:bg-gray-50"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className="px-6 py-2 bg-black text-white rounded-sm text-sm hover:bg-black/80"
+        >
+          {mode === "write" ? "작성 완료" : "수정 완료"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAuth.jsx
+++ b/src/hooks/useAuth.jsx
@@ -1,0 +1,14 @@
+// src/hooks/useAuth.js
+import { useSelector } from "react-redux";
+
+export const useAuth = () => {
+  const { user, isLoggedIn } = useSelector((state) => state.userSlice);
+
+  const isAdmin = user?.user_Role === "admin";
+
+  return {
+    currentUser: user,
+    isAdmin,
+    isLoggedIn,
+  };
+};

--- a/src/pages/helpcenter/HelpNoticePage.jsx
+++ b/src/pages/helpcenter/HelpNoticePage.jsx
@@ -1,108 +1,107 @@
-// src/pages/help/HelpNoticePage.jsx
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { updateUserRole } from "../../redux/slices/features/user/userSlice";
+import { useAuth } from "../../hooks/useAuth";
 
-// 1) 더미데이터에 type을 꼭 넣어야 탭 필터가 먹어요
 const noticeDummy = [
-  {
-    id: 1,
-    title: "추석 연휴 휴무로 인한 배송일정 안내 건",
-    date: "2025.09.30",
-    type: "배송공지",
-  },
+  { id: 1, type: "일반", title: "시스템 점검 공지", date: "2025-12-01" },
   {
     id: 2,
-    title: "고객센터 운영시간 변경 안내 (9/9~)",
-    date: "2025.09.08",
-    type: "고객센터",
+    type: "배송공지",
+    title: "연말연시 배송 지연 안내",
+    date: "2025-11-20",
   },
   {
     id: 3,
-    title: "휴무일(8/15)로 인한 배송지연 안내 건",
-    date: "2025.08.11",
-    type: "배송공지",
+    type: "고객센터",
+    title: "자주 묻는 질문(FAQ) 업데이트",
+    date: "2025-11-15",
   },
   {
     id: 4,
-    title: "개인정보처리방침 전부 개정 안내",
-    date: "2025.07.29",
-    type: "쇼핑몰공지",
-  },
-  {
-    id: 5,
-    title: "시스템 점검 안내 (7/20 02:00~04:00)",
-    date: "2025.07.18",
-    type: "쇼핑몰공지",
-  },
-  {
-    id: 6,
-    title: "여름 시즌 한시적 무료배송 프로모션 안내",
-    date: "2025.06.30",
-    type: "이벤트공지",
-  },
-  {
-    id: 7,
-    title: "택배사 물량 증가로 인한 일부 지역 배송지연 공지",
-    date: "2025.06.12",
-    type: "배송공지",
-  },
-  {
-    id: 8,
-    title: "회원정보 보호를 위한 비밀번호 변경 권장 안내",
-    date: "2025.05.25",
-    type: "고객센터",
-  },
-  {
-    id: 9,
-    title: "5월 가정의 달 이벤트 당첨자 발표",
-    date: "2025.05.10",
-    type: "이벤트공지",
-  },
-  {
-    id: 10,
-    title: "홈페이지 이용약관 개정 안내",
-    date: "2025.04.28",
-    type: "쇼핑몰공지",
+    type: "일반",
+    title: "개인정보 처리방침 변경 예정 안내",
+    date: "2025-11-10",
   },
 ];
 
-// 2) 위에 띄울 탭들
-const tabs = [
-  "전체",
-  "고객센터",
-  "매장공지",
-  "배송공지",
-  "쇼핑몰공지",
-  "이벤트공지",
-];
+const tabs = ["전체", "일반", "배송공지", "고객센터"];
 
 export default function HelpNoticePage() {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { currentUser, isAdmin } = useAuth();
   const [activeTab, setActiveTab] = useState("전체");
   const [keyword, setKeyword] = useState("");
 
-  // 탭 + 검색어 필터
-  const filtered = noticeDummy.filter((n) => {
-    const matchTab = activeTab === "전체" ? true : n.type === activeTab;
-    const matchKeyword =
-      keyword.trim() === ""
-        ? true
-        : n.title.toLowerCase().includes(keyword.toLowerCase());
-    return matchTab && matchKeyword;
-  });
+  const filtered = useMemo(() => {
+    const byTab =
+      activeTab === "전체"
+        ? noticeDummy
+        : noticeDummy.filter((n) => n.type === activeTab);
+    if (!keyword.trim()) return byTab;
+    const q = keyword.trim().toLowerCase();
+    return byTab.filter(
+      (n) =>
+        n.title.toLowerCase().includes(q) || n.type.toLowerCase().includes(q)
+    );
+  }, [activeTab, keyword]);
 
   return (
-    <div>
-      {/* 🔽 키워드 탭 */}
-      <div className="flex gap-6 text-sm mb-4 border-b border-gray-200">
+    <div className="p-6 max-w-4xl mx-auto">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-extrabold text-gray-800">공지사항</h1>
+
+        {isAdmin && (
+          <button
+            onClick={() => navigate("/helpcenter/notice/write")}
+            className="px-4 py-2 bg-indigo-600 text-white font-medium rounded-lg text-sm hover:bg-indigo-700 transition shadow-md"
+          >
+            + 공지사항 작성
+          </button>
+        )}
+      </div>
+
+      {/* 개발자 테스트 UI 이후 서버와 연결 후에는 권한 확인을 서버에서 데이터를 받아서 확인할 예정~*/}
+      {currentUser && (
+        <div className="mb-6 p-4 bg-yellow-100 border border-yellow-300 rounded-xl shadow-inner">
+          <p className="text-sm text-yellow-900 font-semibold mb-3">
+            🧪 개발자 테스트 | 현재 권한: {currentUser.user_Role || "user"}
+          </p>
+          <div className="flex gap-3">
+            <button
+              onClick={() => {
+                dispatch(updateUserRole({ role: "admin" }));
+              }}
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
+            >
+              관리자로 전환
+            </button>
+            <button
+              onClick={() => {
+                dispatch(updateUserRole({ role: "user" }));
+              }}
+              className="px-4 py-2 text-sm bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition"
+            >
+              일반회원으로 전환
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 탭 */}
+      <div className="flex gap-6 text-sm mb-6 border-b border-gray-200">
         {tabs.map((tab) => {
           const on = tab === activeTab;
           return (
             <button
               key={tab}
               onClick={() => setActiveTab(tab)}
-              className={`pb-2 -mb-[1px] border-b-2 transition ${
+              className={`pb-3 -mb-[1px] border-b-2 transition duration-300 ${
                 on
-                  ? "border-[#0FA66E] text-[#0FA66E] font-medium"
-                  : "border-transparent text-gray-500 hover:text-gray-900"
+                  ? "border-indigo-600 text-indigo-600 font-bold"
+                  : "border-transparent text-gray-500 hover:text-gray-700"
               }`}
             >
               {tab}
@@ -111,53 +110,84 @@ export default function HelpNoticePage() {
         })}
       </div>
 
-      {/* 🔽 검색줄 */}
-      <div className="mb-6 flex gap-3">
+      <div className="mb-8 flex gap-3">
         <input
           type="text"
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
-          className="flex-1 border border-gray-200 rounded-sm px-4 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-black"
-          placeholder="검색어를 입력해 주세요."
+          className="flex-1 border border-gray-300 rounded-xl px-4 py-2.5 text-base focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+          placeholder="공지사항 제목 또는 분류를 검색해 주세요."
         />
-        <button className="px-6 bg-black text-white rounded-sm text-sm hover:bg-black/80">
+        <button className="px-6 bg-indigo-600 text-white rounded-xl text-base font-semibold hover:bg-indigo-700 transition shadow-md">
           검색
         </button>
       </div>
 
-      <p className="text-sm text-gray-500 mb-3">총 {filtered.length}건</p>
+      <p className="text-sm text-gray-600 mb-4">
+        총 {filtered.length}건의 공지사항이 있습니다.
+      </p>
 
-      {/* 🔽 리스트 */}
+      {/* 리스트 */}
       <div className="border-t border-gray-300">
         {/* 헤더 */}
-        <div className="grid grid-cols-[80px_1fr_120px] text-xs text-gray-500 py-3 border-b border-gray-200">
-          <div className="pl-3">번호</div>
+        <div
+          className={`grid ${
+            isAdmin
+              ? "grid-cols-[80px_1fr_120px_150px]"
+              : "grid-cols-[80px_1fr_120px]"
+          } text-sm text-gray-600 font-semibold py-4 border-b border-gray-200 bg-gray-50`}
+        >
+          <div className="pl-4">번호</div>
           <div>제목</div>
-          <div className="text-right pr-3">작성일</div>
+          <div className="text-right pr-4">작성일</div>
+          {isAdmin && <div className="text-center">관리</div>}
         </div>
 
+        {/* 목록 아이템 */}
         {filtered.map((notice, idx) => (
           <div
             key={notice.id}
-            className="grid grid-cols-[80px_1fr_120px] items-center py-3 border-b border-gray-100 text-sm hover:bg-gray-50 cursor-pointer"
+            className={`grid ${
+              isAdmin
+                ? "grid-cols-[80px_1fr_120px_150px]"
+                : "grid-cols-[80px_1fr_120px]"
+            } items-center py-4 border-b border-gray-100 text-base hover:bg-indigo-50 transition duration-150 cursor-pointer`}
           >
-            <div className="pl-3 text-gray-500">{idx + 1}</div>
-            <div className="flex items-center gap-2">
-              {/* 타입 뱃지 */}
-              <span
-                className={`text-[11px] px-1.5 py-0.5 rounded-sm ${
-                  notice.type === "이벤트공지"
-                    ? "bg-[#E5F7EF] text-[#0FA66E]"
-                    : "border border-orange-300 text-orange-400"
-                }`}
-              >
-                {notice.type === "이벤트공지" ? "이벤트" : "공지"}
+            <div className="pl-4 text-gray-500 text-sm">{idx + 1}</div>
+            <div className="flex items-center gap-3">
+              <span className="text-xs px-2 py-1 rounded-full bg-indigo-100 text-indigo-700 font-medium">
+                {notice.type}
               </span>
-              <span>{notice.title}</span>
+              <span className="text-gray-800 font-medium">{notice.title}</span>
             </div>
-            <div className="text-right pr-3 text-xs text-gray-400">
+            <div className="text-right pr-4 text-sm text-gray-500">
               {notice.date}
             </div>
+
+            {isAdmin && (
+              <div className="flex gap-2 justify-center">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation(); // 부모 클릭 이벤트 방지
+                    navigate(`/helpcenter/notice/edit/${notice.id}`);
+                  }}
+                  className="px-3 py-1 text-xs border border-gray-300 rounded-lg hover:bg-gray-100 transition"
+                >
+                  수정
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    console.log(
+                      `⚠️ Notice ID ${notice.id} 삭제 시도: API 호출 필요`
+                    );
+                  }}
+                  className="px-3 py-1 text-xs border border-red-400 text-red-600 rounded-lg hover:bg-red-50 transition"
+                >
+                  삭제
+                </button>
+              </div>
+            )}
           </div>
         ))}
       </div>
@@ -210,158 +240,3 @@ export default function HelpNoticePage() {
     </div>
   );
 }
-
-// 이벤트 및 프로모션 타이틀 수정 시 아래 코드로 변환하기
-// // src/pages/help/HelpNoticePage.jsx
-// import React, { useState, useMemo } from "react";
-
-// // ✅ 탭과 1:1 매칭되는 간결 더미데이터 (이벤트 없음)
-// const noticeDummy = [
-//   { id: 1, title: "배송 지연 안내 (태풍 영향)", date: "2025.09.30", type: "일반" },
-//   { id: 2, title: "고객센터 운영시간 변경 (평일 10:00~17:00)", date: "2025.09.08", type: "일반" },
-//   { id: 3, title: "시스템 점검 안내 (9/12 02:00~03:00)", date: "2025.08.11", type: "일반" },
-//   { id: 4, title: "약관 개정 안내", date: "2025.07.29", type: "미정" },
-//   { id: 5, title: "개인정보 처리방침 개정 안내", date: "2025.07.18", type: "미정" },
-//   { id: 6, title: "일부 지역 택배 지연 공지", date: "2025.06.12", type: "일반" },
-//   { id: 7, title: "비밀번호 변경 권장 안내", date: "2025.05.25", type: "일반" },
-//   { id: 8, title: "홈페이지 이용 가이드 갱신", date: "2025.04.28", type: "미정" },
-// ];
-
-// // ✅ 탭 목록 (이벤트 제거)
-// const tabs = ["전체", "일반", "미정"];
-
-// export default function HelpNoticePage() {
-//   const [activeTab, setActiveTab] = useState("전체");
-//   const [keyword, setKeyword] = useState("");
-
-//   // ✅ 탭 + 키워드 필터링 (간결)
-//   const filtered = useMemo(() => {
-//     const byTab =
-//       activeTab === "전체"
-//         ? noticeDummy
-//         : noticeDummy.filter((n) => n.type === activeTab);
-//     if (!keyword.trim()) return byTab;
-//     const q = keyword.trim().toLowerCase();
-//     return byTab.filter(
-//       (n) =>
-//         n.title.toLowerCase().includes(q) ||
-//         n.type.toLowerCase().includes(q)
-//     );
-//   }, [activeTab, keyword]);
-
-//   return (
-//     <div>
-//       {/* 탭 */}
-//       <div className="flex gap-6 text-sm mb-4 border-b border-gray-200">
-//         {tabs.map((tab) => {
-//           const on = tab === activeTab;
-//           return (
-//             <button
-//               key={tab}
-//               onClick={() => setActiveTab(tab)}
-//               className={`pb-2 -mb-[1px] border-b-2 transition ${
-//                 on
-//                   ? "border-black text-black font-medium"
-//                   : "border-transparent text-gray-500 hover:text-gray-900"
-//               }`}
-//             >
-//               {tab}
-//             </button>
-//           );
-//         })}
-//       </div>
-
-//       {/* 검색 */}
-//       <div className="mb-6 flex gap-3">
-//         <input
-//           type="text"
-//           value={keyword}
-//           onChange={(e) => setKeyword(e.target.value)}
-//           className="flex-1 border border-gray-200 rounded-sm px-4 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-black"
-//           placeholder="검색어를 입력해 주세요."
-//         />
-//         <button className="px-6 bg-black text-white rounded-sm text-sm hover:bg-black/80">
-//           검색
-//         </button>
-//       </div>
-
-//       <p className="text-sm text-gray-500 mb-3">총 {filtered.length}건</p>
-
-//       {/* 리스트 */}
-//       <div className="border-t border-gray-300">
-//         {/* 헤더 */}
-//         <div className="grid grid-cols-[80px_1fr_120px] text-xs text-gray-500 py-3 border-b border-gray-200">
-//           <div className="pl-3">번호</div>
-//           <div>제목</div>
-//           <div className="text-right pr-3">작성일</div>
-//         </div>
-
-//         {filtered.map((notice, idx) => (
-//           <div
-//             key={notice.id}
-//             className="grid grid-cols-[80px_1fr_120px] items-center py-3 border-b border-gray-100 text-sm hover:bg-gray-50 cursor-pointer"
-//           >
-//             <div className="pl-3 text-gray-500">{idx + 1}</div>
-//             <div className="flex items-center gap-2">
-//               {/* 단순 배지 (이벤트 분기 제거) */}
-//               <span className="text-[11px] px-1.5 py-0.5 rounded-sm border border-gray-300 text-gray-600">
-//                 {notice.type}
-//               </span>
-//               <span>{notice.title}</span>
-//             </div>
-//             <div className="text-right pr-3 text-xs text-gray-400">
-//               {notice.date}
-//             </div>
-//           </div>
-//         ))}
-//       </div>
-
-//       {/* 페이징 (샘플 고정) */}
-//       <div className="mt-6 flex justify-center gap-2 text-sm">
-//         <button
-//           type="button"
-//           className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-200 text-gray-400 cursor-not-allowed"
-//           disabled
-//         >
-//           «
-//         </button>
-//         <button
-//           type="button"
-//           className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-200 text-gray-400 cursor-not-allowed"
-//           disabled
-//         >
-//           ‹
-//         </button>
-
-//         <button className="w-8 h-8 flex items-center justify-center rounded-full bg-black text-white">
-//           1
-//         </button>
-//         <button className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100">
-//           2
-//         </button>
-//         <button className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100">
-//           3
-//         </button>
-//         <button className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100">
-//           4
-//         </button>
-//         <button className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-gray-100">
-//           5
-//         </button>
-
-//         <button
-//           type="button"
-//           className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-200 hover:bg-gray-50"
-//         >
-//           ›
-//         </button>
-//         <button
-//           type="button"
-//           className="w-8 h-8 flex items-center justify-center rounded-full border border-gray-200 hover:bg-gray-50"
-//         >
-//           »
-//         </button>
-//       </div>
-//     </div>
-//   );
-// }

--- a/src/pages/helpcenter/admin/NoticeEditPage.jsx
+++ b/src/pages/helpcenter/admin/NoticeEditPage.jsx
@@ -1,0 +1,69 @@
+import { useNavigate, useParams } from "react-router-dom";
+import { useAuth } from "../../../hooks/useAuth";
+import { useEffect } from "react";
+
+export default function NoticeEditPage() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const { currentUser, isAdmin, isLoggedIn } = useAuth();
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      alert("로그인이 필요합니다");
+      navigate("/loginpage");
+      return;
+    }
+
+    if (!isAdmin) {
+      alert("관리자 권한이 필요합니다");
+      navigate("/helpcenter");
+      return;
+    }
+  }, [isLoggedIn, isAdmin, navigate]);
+
+  if (!isLoggedIn || isAdmin) {
+    return null;
+  }
+
+  const noticeData = {
+    id,
+    title: "기존 제목",
+    type: "일반",
+    content: "기존 내용입니다",
+  };
+
+  const handleSave = (FormData) => {
+    console.log("수정 데이터:", { id, ...formData });
+    alert("공지사항이 수정되었습니다.");
+    navigate("/helpcenter");
+    return (
+      <div className="max-w-4xl mx-auto p-6">
+        <div className="mb-6">
+          <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
+            <button
+              onClick={() => navigate("/helpcenter")}
+              className="hover:text-black"
+            >
+              고객센터
+            </button>
+            <span>›</span>
+            <span className="text-black">공지사항 수정</span>
+          </div>
+          <h1 className="text-2xl font-bold">공지사항 수정</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            작성자: {currentUser?.name}
+          </p>
+        </div>
+
+        <div className="bg-white border border-gray-200 rounded-lg p-6">
+          <NoticeForm
+            mode="edit"
+            initialData={noticeData}
+            onSave={handleSave}
+            onCancel={() => navigate("/helpcenter")}
+          />
+        </div>
+      </div>
+    );
+  };
+}

--- a/src/pages/helpcenter/admin/NoticeWritePage.jsx
+++ b/src/pages/helpcenter/admin/NoticeWritePage.jsx
@@ -1,0 +1,62 @@
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../../hooks/useAuth";
+import { useEffect } from "react";
+import NoticeForm from "../../../components/helpcenter/NoticeForm";
+
+export default function NoticeWritePage() {
+  const navigate = useNavigate();
+  const { currentUser, isAdmin, isLoggedIn } = useAuth();
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      alert("로그인이 필요합니다");
+      navigate("/loginpage");
+      return;
+    }
+
+    if (!isAdmin) {
+      alert("관리자 권한이 필요합니다");
+      navigate("/helpcenter");
+      return;
+    }
+  }, [isLoggedIn, isAdmin, navigate]);
+
+  if (!isLoggedIn || !isAdmin) {
+    return null;
+  }
+
+  const handleSave = (formData) => {
+    console.log("작성 데이터:", formData);
+    alert("공지사항이 작성되었습니다~");
+    navigate("/helpcenter");
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <div className="mb-6">
+        <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
+          <button
+            onClick={() => navigate("/helpcenter")}
+            className="hover:text-black"
+          >
+            고객센터
+          </button>
+          <span>›</span>
+          <span className="text-black">공지사항 작성</span>
+        </div>
+        <h1 className="text-2xl font-bold">공지사항 작성</h1>
+        <p className="text-sm text-gray-500 mt-1">
+          작성자: {currentUser?.name}
+        </p>
+      </div>
+
+      <div className="bg-white border border-gray-200 rounded-lg p-6">
+        <NoticeForm
+          mode="write"
+          onSave={handleSave}
+          onCancel={() => navigate("/helpcenter")}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/redux/slices/features/user/loginSlice.jsx
+++ b/src/redux/slices/features/user/loginSlice.jsx
@@ -1,6 +1,6 @@
 export const loginSlice = {
-  //prettier-ignore
-  login: (state, action) => {  // State를 변경하는 login 함수를 정의
+  // prettier-ignore
+  login: (state, action) => { // State를 변경하는 login 함수를 정의
     const { login_Id, password } = action.payload;
     // LoginComponent에서 Props로 전달받을 예정
     // 회원가입 폼에서는 login_id 사용
@@ -10,7 +10,7 @@ export const loginSlice = {
 
     // prettier-ignore
     const user = users.find((u) => u.login_Id === login_Id && u.password === password);
-    // 로컬스토리지안에서 꺼낸 users가 props로 받은 login_id와 같고, users의 패스워드1이 props로 받은 password와 같다면 user에 저장
+    // 로컬스토리지안에서 꺼낸 users가 props로 받은 login_id와 같고, users의 패스워드가 props로 받은 password와 같다면 user에 저장
 
     if (user) {
       // 로그인 성공
@@ -21,7 +21,7 @@ export const loginSlice = {
 
       localStorage.setItem("token", state.token); // 로컬스토리지에 저장할때는 Key / Value 형태 여기서 키도 문자열, 로컬스토리지 데이터도 문자열이다.
       localStorage.setItem("currentUser", JSON.stringify(user)); // 해당 Stringify는 객체를 문자열로 변환해준다.
-      console.log("✅ 여기는 LoginSlice: 로그인 성공", user);
+      console.log("✅ LoginSlice: 로그인 성공", user);
     } else {
       // 로그인 실패
       state.error = "아이디 또는 비밀번호가 틀렸습니다."; // 로그인이 실패하게되면 userSlice의 state중 error에 해당 문자열을 저장하고 LoginComponent에서 error가 출력되게 해놓았다.
@@ -29,19 +29,19 @@ export const loginSlice = {
     }
   },
 
-  //prettier-ignore
+  // prettier-ignore
   logout: (state) => { // 로그아웃 Reducer
     state.user = null; // null 값으로 변경
     state.isLoggedIn = false; // false 값으로 변경
     state.token = null; // null 값으로 변경
     state.error = null; // null 값으로 변경 
-// 여기서 로그아웃은 Header의 로그아웃버튼을 클릭하면 logout() Reducer가 실행되면서 -> 유저정보를 null 또는 false로 만들고 localstorage에 저장된 데이터도 remove 한다.
+    // 여기서 로그아웃은 Header의 로그아웃버튼을 클릭하면 logout() Reducer가 실행되면서 -> 유저정보를 null 또는 false로 만들고 localstorage에 저장된 데이터도 remove 한다.
     localStorage.removeItem("token"); // 로컬스토리지의 해당 키값을 지운다. 밸류도 같이 지워진다.
     localStorage.removeItem("currentUser"); // 로컬스토리지의 해당 키값을 지운다. 밸류도 같이 지워진다.
-    console.log("✅ 여기는 LoginSlice: 로그아웃 완료");  // 해당 로그아웃 Reducer가 실행되고 마지막에 로그가 출력된다.
+    console.log("✅ LoginSlice: 로그아웃 완료"); // 해당 로그아웃 Reducer가 실행되고 마지막에 로그가 출력된다.
   },
 
-  // 🔹 로그인 상태 복구 (restoreLogin) 이건 현재 안쓰이고 있다★☆★
+  // 🔹 로그인 상태 복구 (restoreLogin)
   // prettier-ignore
   restoreLogin: (state) => { // 해당 Reducer가 실행되면 
     const token = localStorage.getItem("token"); // 로컬스토리지에 저장되있는 token 데이터를 불러온다
@@ -50,7 +50,24 @@ export const loginSlice = {
       state.user = JSON.parse(user); // user를 객체로 변환해서 user 상태에 저장
       state.isLoggedIn = true; // 로그인확인 상태도 true로 저장
       state.token = token; // 현재 token도 현재상태에 저장
-      console.log("✅ 여기는 LoginSlice : 로그인 상태 복구");
+      console.log("✅ LoginSlice: 로그인 상태 복구");
+    }
+  },
+
+  updateUserRole: (state, action) => {
+    const { role } = action.payload; // "admin" or "user"
+
+    if (state.user) {
+      state.user.user_Role = role;
+
+      // localStorage도 동기화
+      const currentUser = JSON.parse(localStorage.getItem("currentUser"));
+      if (currentUser) {
+        currentUser.user_Role = role;
+        localStorage.setItem("currentUser", JSON.stringify(currentUser));
+      }
+
+      console.log(`✅ LoginSlice: 권한 변경 완료 -> ${role}`);
     }
   },
 };

--- a/src/redux/slices/features/user/signUpSlice.jsx
+++ b/src/redux/slices/features/user/signUpSlice.jsx
@@ -1,5 +1,3 @@
-// redux/auth/signupSlice.js
-
 export const signupSlice = {
   // prettier-ignore
   signUp: (state, action) => { // signUp Reducer
@@ -23,6 +21,7 @@ export const signupSlice = {
       ...newUserData, // newUserData의 기존데이터를 객체를 벗긴 후에 데이터를 넣고
       terms: action.payload.terms, // terms: 속성에 action.payload로 받은 .terms를 저장
       user_Level: "Bronze", // 생성 시 유저등급을 기본 Bronze로 생성
+      user_Role: "user", // 기본권한 지정
       createdAt: new Date().toISOString(), // 생성일자를 new Date 생성자를 실행과 동시에 toISOString으로 변환
     };
     users.push(userWithId);
@@ -30,7 +29,7 @@ export const signupSlice = {
     // 4. 로컬스토리지에 저장
     localStorage.setItem("users", JSON.stringify(users));
 
-    console.log("✅ 여기는 SignUpSlice: 회원가입 완료", userWithId);
+    console.log("✅ SignUpSlice: 회원가입 완료", userWithId);
     state.error = null; // 성공 시 에러 초기화
   },
 };

--- a/src/redux/slices/features/user/userSlice.jsx
+++ b/src/redux/slices/features/user/userSlice.jsx
@@ -1,27 +1,34 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { signupSlice } from "./signUpSlice";
+// 프로젝트 구조에 맞게 경로를 수정해 주세요.
 import { loginSlice } from "./loginSlice";
+import { signupSlice } from "./signUpSlice";
 
 const initialState = {
-  user: null,
-  isLoggedIn: false,
-  token: null,
-  error: null,
+  user: null, // 현재 로그인한 사용자 정보
+  isLoggedIn: false, // 로그인 상태
+  token: null, // 인증 토큰
+  error: null, // 에러 메시지
 };
 
 const userSlice = createSlice({
-  name: "userSlice",
+  name: "user",
   initialState,
   reducers: {
     clearError: (state) => {
       state.error = null;
     },
-    ...signupSlice,
     ...loginSlice,
+    ...signupSlice,
   },
 });
 
-export const { signUp, login, logout, clearError, restoreLogin } =
-  userSlice.actions;
+export const {
+  signUp,
+  login,
+  logout,
+  clearError,
+  restoreLogin,
+  updateUserRole,
+} = userSlice.actions;
 
 export default userSlice.reducer;

--- a/src/router/helpRouter.jsx
+++ b/src/router/helpRouter.jsx
@@ -1,0 +1,94 @@
+import { lazy, Suspense } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+
+const useAuth = () => ({
+  isAdmin: localStorage.getItem("currentUser")?.includes('"user_Role":"admin"'),
+  isLoggedIn: !!localStorage.getItem("currentUser"),
+});
+
+// 관리자 권한 보호 컴포넌트
+function AdminRoute({ children }) {
+  const { isAdmin, isLoggedIn } = useAuth();
+  const location = useLocation();
+
+  // 1. 로그인 여부 확인
+  if (!isLoggedIn) {
+    console.warn("AdminRoute: 로그인이 필요합니다.");
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  // 2. 관리자 권한 확인
+  if (!isAdmin) {
+    console.warn("AdminRoute: 관리자 권한이 필요합니다.");
+    return <Navigate to="/" replace />;
+  }
+  return children;
+}
+const Loading = <div>고객센터 페이지 로딩 중...</div>;
+
+const HelpNoticePage = lazy(() => import("../pages/helpcenter/HelpNoticePage"));
+const HelpFaqPage = lazy(() => import("../pages/helpcenter/HelpFaqPage"));
+const HelpInquiryPage = lazy(() =>
+  import("../pages/helpcenter/HelpInquiryPage")
+);
+
+const NoticeWritePage = lazy(() =>
+  import("../pages/helpcenter/admin/NoticeWritePage")
+);
+const NoticeEditPage = lazy(() =>
+  import("../pages/helpcenter/admin/NoticeEditPage")
+);
+
+const helpRouter = () => {
+  return [
+    {
+      index: true, // 기본 경로 (/helpcenter)
+      element: (
+        <Suspense fallback={Loading}>
+          <HelpNoticePage />
+        </Suspense>
+      ),
+    },
+    {
+      path: "faq",
+      element: (
+        <Suspense fallback={Loading}>
+          <HelpFaqPage />
+        </Suspense>
+      ),
+    },
+    {
+      path: "inquiry",
+      element: (
+        <Suspense fallback={Loading}>
+          <HelpInquiryPage />
+        </Suspense>
+      ),
+    },
+    // --- 관리자 전용 라우트 ---
+    {
+      path: "notice/write",
+      element: (
+        // AdminRoute로 래핑하여 권한 보호
+        <AdminRoute>
+          <Suspense fallback={Loading}>
+            <NoticeWritePage />
+          </Suspense>
+        </AdminRoute>
+      ),
+    },
+    {
+      path: "notice/edit/:id",
+      element: (
+        // AdminRoute로 래핑하여 권한 보호
+        <AdminRoute>
+          <Suspense fallback={Loading}>
+            <NoticeEditPage />
+          </Suspense>
+        </AdminRoute>
+      ),
+    },
+  ];
+};
+
+export default helpRouter;

--- a/src/router/root.jsx
+++ b/src/router/root.jsx
@@ -3,6 +3,7 @@ import { createBrowserRouter } from "react-router-dom";
 import AdminIndex from "../pages/admin/AdminIndex";
 import adminRouter from "./adminRouter";
 import mypageRouter from "./mypageRouter";
+import helpRouter from "./helpRouter";
 
 const Main = lazy(() => import("../pages/user/MainPage"));
 const LoginPage = lazy(() => import("../pages/user/LoginPage"));
@@ -20,11 +21,6 @@ const OrderComplete = lazy(() => import("../pages/order/OrderCompletePage"));
 const Cart = lazy(() => import("../pages/cart/CartPage"));
 
 const Helpcenter = lazy(() => import("../pages/helpcenter/HelpCenterPage"));
-const HelpNoticePage = lazy(() => import("../pages/helpcenter/HelpNoticePage"));
-const HelpInquiryPage = lazy(() =>
-  import("../pages/helpcenter/HelpInquiryPage")
-);
-const HelpFaqPage = lazy(() => import("../pages/helpcenter/HelpFaqPage"));
 const ProductQuestionPage = lazy(() =>
   import("../components/productquestion/ProductQuestion")
 );
@@ -149,11 +145,7 @@ const root = createBrowserRouter([
   {
     path: "/helpcenter",
     element: <Helpcenter />,
-    children: [
-      { index: true, element: <HelpNoticePage /> }, // /helpcenter
-      { path: "faq", element: <HelpFaqPage /> }, // /helpcenter/faq
-      { path: "inquiry", element: <HelpInquiryPage /> }, // /helpcenter/inquiry
-    ],
+    children: helpRouter(),
   },
   {
     path: "productquestion",


### PR DESCRIPTION
◾ loginSlice -> 유저 권한 업데이트 reducer 임시 추가
◾ signUpSlice -> 회원가입 시 기본권한("user") 부여
◾ hooks 폴더 생성 -> useAuth.jsx (CustomHook) 생성
◾ HelpNoticePage -> 테스트용 관리자권한 기능 추가, 관리자 전환 시 페이지변환(기능추가) 생성 
◾ helpRouter.jsx  고객센터 router 생성 
◾ components -> helpcenter 폴더 생성 -> NoticeForm Component 생성 
◾ NoticeWriterPage 관리자 공지사항 입력페이지 생성
◾ NoticeEditPage 관리자 공지사항 수정페이지 기능 구현중
◾ (기존) root -> helpcenter 부모로만 구성 -> 자식들은 별도 라우터에서 구현