### PR TITLE
 [프론트] 리뷰 목록 조회 - 정렬옵션, 평균별점(평점) 연결

### DIFF
--- a/src/api/review/reviewApi.js
+++ b/src/api/review/reviewApi.js
@@ -3,10 +3,13 @@ import axios from "axios";
 export const API_SERVER_HOST = "http://localhost:8080";
 const prefix = `${API_SERVER_HOST}/api/review`;
 
-export const reviewList = async (productId) => {
-  const { data } = await axios.get(`${prefix}/product/${productId}`);
-  console.log("API 요청 data => ", data);
-  console.log("productId => ", productId);
+export const reviewList = async (productId, sort) => {
+  const { data } = await axios.get(`${prefix}/product/${productId}`, {
+    params: {
+      sort: sort,
+    },
+  });
+  console.log("API 요청 data => ", data, "productId => ", productId);
   return data;
 };
 
@@ -18,19 +21,22 @@ export const getMyReviews = async (userId) => {
 };
 
 export const reviewAdd = async (review) => {
-  const { data } = await axios.post(`${prefix}/reviewAdd`, review);
+  const { data } = await axios.post(`${prefix}/add`, review);
   console.log("data => ", data);
   return data;
 };
 
 export const reviewModify = async (reviewId, updatedReview) => {
-  const { data } = await axios.put(`${prefix}/${reviewId}`, updatedReview);
+  const { data } = await axios.put(
+    `${prefix}/modify/${reviewId}`,
+    updatedReview
+  );
   console.log("reviewId => ", reviewId);
   return data;
 };
 
 export const reviewDelete = async (reviewId) => {
-  const { data } = await axios.delete(`${prefix}/${reviewId}`);
+  const { data } = await axios.delete(`${prefix}/delete/${reviewId}`);
   console.log("delete reviewId => ", reviewId);
   return data;
 };

--- a/src/components/review/ReviewListComponent.jsx
+++ b/src/components/review/ReviewListComponent.jsx
@@ -1,19 +1,20 @@
 import { useEffect, useRef, useState } from "react";
 import ReviewRatingComponent from "./ReviewRatingComponent";
 import { reviewList } from "../../api/review/reviewapi";
-import { Database } from "lucide-react";
 
 const ReviewListComponent = () => {
+  const sortOptions = [
+    { label: "최신순", value: "latest" },
+    { label: "좋아요순", value: "like" },
+    { label: "높은별점순", value: "ratingDesc" },
+    { label: "낮은별점순", value: "ratingAsc" },
+  ];
+
   const [reviews, setReviews] = useState([]);
   const [openDropdown, setOpenDropdown] = useState(null); // 'sort', 'option', null
   const [showComments, setShowComments] = useState({}); //리뷰 댓글의 열림/닫힘(on/off) 여부
-  const [selectedSort, setSelectedSort] = useState("최신순");
-  const [selectedOption, setSelectedOption] = useState("옵션");
+  const [selectedSort, setSelectedSort] = useState(sortOptions[0]); //기본 최신순
   const sortRef = useRef();
-  const optionRef = useRef();
-
-  const sortOptions = ["최신순", "좋아요순", "높은별점순", "낮은별점순"];
-  const options = ["옵션1", "옵션2", "옵션3", "옵션4"];
 
   const initialComments = [
     {
@@ -42,21 +43,19 @@ const ReviewListComponent = () => {
   //리뷰 목록 조회
   useEffect(() => {
     const getReviews = async () => {
-      const reviews = await reviewList(1);
+      const reviews = await reviewList(1, selectedSort.value);
       console.log("상품 리뷰 => ", reviews);
+      console.log("sort옵션 => ", selectedSort.value);
       setReviews(reviews);
     };
     getReviews();
-  }, []);
+  }, [selectedSort]);
 
-  //정렬, 옵션 드롭다운
+  //정렬 드롭다운
   useEffect(() => {
     const handleClickOutside = (e) => {
       if (sortRef.current && !sortRef.current.contains(e.target)) {
         setOpenDropdown((prev) => (prev === "sort" ? null : prev));
-      }
-      if (optionRef.current && !optionRef.current.contains(e.target)) {
-        setOpenDropdown((prev) => (prev === "option" ? null : prev));
       }
     };
 
@@ -90,7 +89,7 @@ const ReviewListComponent = () => {
               }
               className="px-2 py-0.5 text-xs bg-white border border-gray-300 rounded-md text-gray-700 cursor-pointer hover:border-gray-400 transition focus:outline-none flex items-center justify-between min-w-[90px]"
             >
-              <span>{selectedSort}</span>
+              <span>{selectedSort.label}</span>
               <span className="ml-2 text-gray-600 text-lg">▾</span>
             </button>
 
@@ -98,43 +97,14 @@ const ReviewListComponent = () => {
               <div className="absolute mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg z-10 overflow-hidden">
                 {sortOptions.map((option) => (
                   <div
-                    key={option}
+                    key={option.value}
                     className="px-3 py-2 hover:bg-gray-50 cursor-pointer text-xs transition-colors"
                     onClick={() => {
                       setSelectedSort(option);
                       setOpenDropdown(null);
                     }}
                   >
-                    {option}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* 옵션 */}
-          <div className="relative" ref={optionRef}>
-            <button
-              onClick={() =>
-                setOpenDropdown(openDropdown === "option" ? null : "option")
-              }
-              className="px-2 py-0.5 text-xs bg-white border border-gray-300 rounded-md text-gray-700 cursor-pointer hover:border-gray-400 transition focus:outline-none flex items-center justify-between min-w-[90px]"
-            >
-              <span>{selectedOption}</span>
-              <span className="ml-2 text-gray-600 text-lg">▾</span>
-            </button>
-            {openDropdown === "option" && (
-              <div className="absolute mt-1 w-full bg-white border border-gray-300 rounded-md shadow-lg z-10 overflow-hidden">
-                {options.map((option) => (
-                  <div
-                    key={option}
-                    className="px-3 py-2 hover:bg-gray-50 cursor-pointer text-xs transition-colors"
-                    onClick={() => {
-                      setSelectedOption(option);
-                      setOpenDropdown(null);
-                    }}
-                  >
-                    {option}
+                    {option.label}
                   </div>
                 ))}
               </div>
@@ -155,7 +125,7 @@ const ReviewListComponent = () => {
                 <div className="flex justify-between items-center mb-2">
                   <div className="flex items-center space-x-3">
                     <span className="text-gray-900 font-semibold text-base">
-                      {review.userName || "유저아이디"}
+                      {review.loginId}
                     </span>
                     <span className="text-xs text-gray-500">
                       {review.createdAt?.slice(0, 10).replace(/-/g, ".") ||

--- a/src/components/review/ReviewSee.jsx
+++ b/src/components/review/ReviewSee.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 const ReviewSee = ({ closeModal, review }) => {
+  console.log("리뷰 보기 => ", review);
   const [currentRating, setCurrentRating] = useState(0);
   const [reviewContent, setReviewContent] = useState("");
   const [images] = useState([1, 2, 3, 4, 5]); // 임시 이미지 데이터

--- a/src/components/user/mypage/MyPageReviewList.jsx
+++ b/src/components/user/mypage/MyPageReviewList.jsx
@@ -5,6 +5,7 @@ import { getMyReviews } from "../../../api/review/reviewapi";
 
 const MyPageReviewList = () => {
   const [reviewModal, setReviewModal] = useState(false);
+  const [reviewSeeModal, setReviewSeeModal] = useState(false);
   const [selectedReviewEdit, setSelectedReviewEdit] = useState(null);
   const [selectedReviewSee, setSelectedReviewSee] = useState(null);
   const [reviews, setReviews] = useState([]);
@@ -17,12 +18,6 @@ const MyPageReviewList = () => {
     };
     getReviews();
   }, []);
-
-  useEffect(() => {
-    if (selectedReviewSee) {
-      setSelectedReviewSee(true);
-    }
-  }, [selectedReviewSee]);
 
   const reviewUpdatedHandler = (updatedReview) => {
     if (updatedReview.deleted) {
@@ -128,7 +123,10 @@ const MyPageReviewList = () => {
                     리뷰수정
                   </button>
                   <button
-                    onClick={() => setSelectedReviewSee(item)}
+                    onClick={() => {
+                      setSelectedReviewSee(item);
+                      setReviewSeeModal(true);
+                    }}
                     className="px-4 py-1.5 text-xs border border-zinc-300 rounded hover:bg-zinc-50 cursor-pointer"
                   >
                     리뷰보기
@@ -150,7 +148,7 @@ const MyPageReviewList = () => {
         {reviewModal && selectedReviewEdit && (
           <ReviewModifyDelete
             closeModal={() => setReviewModal(false)}
-            review={setSelectedReviewEdit}
+            review={selectedReviewEdit}
             update={reviewUpdatedHandler}
           />
         )}
@@ -159,7 +157,7 @@ const MyPageReviewList = () => {
         {selectedReviewSee && (
           <ReviewSee
             closeModal={() => setSelectedReviewSee(false)}
-            review={setSelectedReviewSee}
+            review={selectedReviewSee}
           />
         )}
       </div>


### PR DESCRIPTION
- 리뷰 Api reviewList 수정 :
  - 백엔드 리뷰 컨트롤러 경로 수정으로 프론트도 경로수정
  - reviewList에 sort 추가
- 리뷰리스트컴포넌트 :
  - options, selectedOption (옵션) 삭제 : 제품 옵션별로 리뷰 보기를 위해 만들었으나 당장 필요 없다 판단돼서 삭제
  - sort (정렬) 수정
  - 리뷰에 작성한 유저의 아이디를 보기위해 loginId 추가
- ReviewSee : 콘솔로그 삭제
- MypageReviewList :
  - 수정하기, 리뷰보기 버튼 눌렀을때 리뷰 내용과 별점이 보이지 않는 문제 때문에 useEffect 삭제, 일부 코드 수정