### PR TITLE
[프론트] 회원가입 중복확인 기능 추가

### DIFF
--- a/src/api/user/userapi.js
+++ b/src/api/user/userapi.js
@@ -28,7 +28,7 @@ export const signUpApi = async (signUpForm) => {
       address: signUpForm.address, // 기본주소
       addressDetail: signUpForm.addressDetail, // 상세주소
       smsAgreement: signUpForm.smsAgreement, // SMS 알림 동의
-      emailAgreement: signUpForm.emailAgreement, // Email 알림 동의
+      emailAgreement: signUpForm.emailAgreement // Email 알림 동의
     };
 
     console.log("백엔드로 보내는 데이터 콘솔", requestData);
@@ -53,6 +53,20 @@ export const loginApi = async (loginForm) => {
     return res.data;
   } catch (error) {
     console.error("로그인 API 에러", error);
+    throw error;
+  }
+};
+
+//prettier-ignore
+export const checkLoginIdApi = async (loginId) => {
+  try {
+    console.log("아이디 중복확인 API", loginId);
+    const response = await axios.get(`${USER_API}/check-loginId`, { params: { loginId } });  // 받은 loginId를 get사용 params 방식으로 전달
+    // Query Parameter 형태로 변환. 즉, .../api/user/check-loginId?loginId=사용자입력값 형태로 요청이 전송됨
+    console.log("백엔드 응답 중복확인", response);
+    return response.data;
+  } catch (error) {
+    console.log("중복확인 API 에러", error);
     throw error;
   }
 };

--- a/src/components/user/util/validation.jsx
+++ b/src/components/user/util/validation.jsx
@@ -1,0 +1,43 @@
+//prettier-ignore
+export const validate = (signUpForm) => { // 유효성 검사 함수
+    const e = {}; // 빈 객체 속성 및 데이터추가 가능
+    const loginIdRegex = /^[a-zA-Z0-9]+$/; // 영어,숫자만 허용
+
+    // 아이디 검사 로직
+    if (!signUpForm.loginId || signUpForm.loginId.length < 4) { e.loginId = "아이디는 4자 이상 입력하세요."; 
+    } else if (!loginIdRegex.test(signUpForm.loginId)) { e.loginId = "아이디는 영어(대/소문자와)와 숫자만 사용할 수 있습니다."; }
+
+    // 비밀번호 검사 로직
+    if (!signUpForm.password || signUpForm.password.length < 8)  e.password = "비밀번호는 8자 이상 입력하세요.";
+    if (signUpForm.confirmPassword !== signUpForm.password)      e.confirmPassword = "비밀번호가 일치하지 않습니다.";
+
+    // 이름 검사 로직
+    if (!signUpForm.name) e.name = "이름을 입력하세요.";
+
+    // 생년월일 검사 로직
+    if (!signUpForm.birthY || !signUpForm.birthM || !signUpForm.birthD) { e.birthDate = "생년월일을 모두 입력하세요.";
+    } else { const year = parseInt(signUpForm.birthY);
+             const month = parseInt(signUpForm.birthM);
+             const day = parseInt(signUpForm.birthD);
+      if (year < 1900 || year > new Date().getFullYear()) { e.birthDate = "올바른 연도를 입력하세요.";
+      } else if (month < 1 || month > 12) {   e.birthDate = "월은 1~12 사이여야 합니다.";
+      } else if (day < 1 || day > 31)     {   e.birthDate = "일은 1~31 사이여야 합니다.";  }}
+
+    // 이메일 검사 로직
+    if (!signUpForm.email || !/^\S+@\S+\.\S+$/.test(signUpForm.email))            e.email = "이메일 형식 오류";
+
+    // 연락처 검사 로직
+    if (!signUpForm.phoneNumber || !/^\d{10,11}$/.test(signUpForm.phoneNumber))   e.phoneNumber = "휴대전화 숫자만 10~11자리 입력하세요.";
+
+    // 우편번호 검사 로직
+    if (!signUpForm.postalCode || !/^\d{5}$/.test(signUpForm.postalCode))         e.postalCode = "우편번호는 5자리 숫자입니다.";
+
+    // 일반주소 검사 로직
+    if (!signUpForm.address) e.address = "기본 주소를 입력하세요.";           
+
+    // 상세주소 검사 로직
+    if (!signUpForm.addressDetail) e.addressDetail = "상세 주소를 입력하세요.";
+
+    // 에러 객체 반환~
+    return e;
+  };

--- a/src/redux/slices/features/user/authSlice.jsx
+++ b/src/redux/slices/features/user/authSlice.jsx
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { loginApi } from "../../../../api/user/userapi";
+import { loginApi } from "../../../../api/user/userApi";
 
 export const loginAsyncThunk = createAsyncThunk(
   "auth/login",
@@ -26,7 +26,7 @@ const initialState = {
   isLoggedIn: false, // 로그인 상태!
   //Todo : token : null, JWT + Security 추가 후 진행 할 예정
   error: null, // 에러 상태
-  loading: false, // 로딩 상태
+  loading: false // 로딩 상태
 };
 
 // prettier-ignore

--- a/src/redux/slices/features/user/signUpSlice.jsx
+++ b/src/redux/slices/features/user/signUpSlice.jsx
@@ -1,5 +1,5 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { signUpApi } from "../../../../api/user/userapi";
+import { checkLoginIdApi, signUpApi } from "../../../../api/user/userApi";
 
 //prettier-ignore
 export const signUpThunk = createAsyncThunk("signup/signup", async(signUpForm, {rejectWithValue})=> {
@@ -17,12 +17,32 @@ export const signUpThunk = createAsyncThunk("signup/signup", async(signUpForm, {
  }
 );
 
+// prettier-ignore
+export const checkLoginIdThunk = createAsyncThunk(
+  "signup/checkLoginId",
+  async (loginId, { rejectWithValue }) => { // 해당 loginId를 받으면 자동으로 Thunk Action 실행
+    try {
+      const response = await checkLoginIdApi(loginId); // 중복확인용 API 호출 받은 loginId를 API로 전달
+      console.log("백엔드 아이디 중복확인 응답 콘솔", response);
+      return response;
+    } catch (error) {
+      console.log("여기는 백엔드 아이디 중복확인 에러 콘솔", error);
+      return rejectWithValue(
+        error.message || "아이디 중복 확인에 실패하였습니다."
+      );
+    }
+  }
+);
+
 const signUpSlice = createSlice({
   name: "signup",
   initialState: {
     loading: false,
     error: null,
     signUpSuccess: false,
+    checkingLoginId: false,
+    loginIdCheckResult: null,
+    loginIdCheckError: null
   },
   reducers: {
     // 회원가입 성공 상태 초기화
@@ -33,6 +53,10 @@ const signUpSlice = createSlice({
     clearError: (state) => {
       state.error = null;
     },
+    resetLoginIdCheck: (state) => {
+      state.loginIdCheckResult = null;
+      state.loginIdCheckError = null;
+    }
   },
 
   extraReducers: (builder) => {
@@ -53,9 +77,26 @@ const signUpSlice = createSlice({
         state.error = action.payload;
         state.signUpSuccess = false;
         console.log("SignUpSlice 콘솔 회원 가입 실패 :", action.payload);
+      })
+      .addCase(checkLoginIdThunk.pending, (state) => {
+        state.checkingLoginId = true;
+        state.loginIdCheckError = null;
+      })
+      .addCase(checkLoginIdThunk.fulfilled, (state, action) => {
+        state.checkingLoginId = false;
+        state.loginIdCheckResult = action.payload;
+        state.loginIdCheckError = null;
+        console.log("SignUpSlice 아이디 중복 확인 성공", action.payload);
+      })
+      .addCase(checkLoginIdThunk.rejected, (state, action) => {
+        state.checkingLoginId = false;
+        state.loginIdCheckError = action.payload;
+        state.loginIdCheckResult = null;
+        console.log("SignUpSlice 아이디 중복 확인 실패", action.payload);
       });
-  },
+  }
 });
 
-export const { resetSignUpSuccess, clearError } = signUpSlice.actions;
+export const { resetSignUpSuccess, clearError, resetLoginIdCheck } =
+  signUpSlice.actions;
 export default signUpSlice.reducer;


### PR DESCRIPTION
- 회원가입 진행 시, 아이디 중복확인 유효성검사 및 기능 추가
- 기존 유효성검사 (vaildate) User 폴더 util 추가하여 validation.js 분리하여 사용 infoStep validation 적용 유지보수 접근 용이하게 변경
- infoStep handleDuplicateChaeck 중복확인 기능 추가
- infoStep handleDuplicateChaeck 내부 signUpSliceAsyncThunk 사용 signUpSlice 중복확인용 Thunk 및 API 추가
- userapi -> userApi 변경
- userApi -> checkLoginIdApi 구현
- 프론트에서 백엔드 연결 후 테스트 완료