### PR TITLE
[프론트] 개인정보조회 기능 구현

### DIFF
--- a/src/api/user/userapi.js
+++ b/src/api/user/userapi.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
-const APISERVER = "http://localhost:8080";
-const USER_API = `${APISERVER}/api/user`;
+const API_SERVER = "http://localhost:8080";
+const USER_API = `${API_SERVER}/api/user`;
 
 export const signUpApi = async (signUpForm) => {
   try {
@@ -28,31 +28,34 @@ export const signUpApi = async (signUpForm) => {
       address: signUpForm.address, // 기본주소
       addressDetail: signUpForm.addressDetail, // 상세주소
       smsAgreement: signUpForm.smsAgreement, // SMS 알림 동의
-      emailAgreement: signUpForm.emailAgreement // Email 알림 동의
+      emailAgreement: signUpForm.emailAgreement, // Email 알림 동의
     };
 
     console.log("백엔드로 보내는 데이터 콘솔", requestData);
 
     const res = await axios.post(`${USER_API}/signup`, requestData);
-    console.log("여기는 응답 데이터 확인 콘솔", res.data);
+    console.log("1) 여기는 응답 데이터 확인 콘솔", res.data);
     return res.data;
   } catch (error) {
-    console.error("회원가입 API 에러", error.response?.data || error.message);
+    console.error(
+      "2) 회원가입 API 에러",
+      error.response?.data || error.message
+    );
     throw error.response?.data.message || "회원가입에 실패했습니다.";
   }
 };
 
 export const loginApi = async (loginForm) => {
   try {
-    console.log("로그인 API 호출 + 요청 데이터", loginForm);
+    console.log("1) 로그인 API 호출 + 요청 데이터", loginForm);
     const res = await axios.post(`${USER_API}/login`, loginForm);
-    console.log("로그인 API + 응답 데이터", res.data);
+    console.log("2) 로그인 API + 응답 데이터", res.data);
     if (!res.data) {
       throw new Error("데이터가 없습니다");
     }
     return res.data;
   } catch (error) {
-    console.error("로그인 API 에러", error);
+    console.error("3) 로그인 API 에러", error);
     throw error;
   }
 };
@@ -60,13 +63,38 @@ export const loginApi = async (loginForm) => {
 //prettier-ignore
 export const checkLoginIdApi = async (loginId) => {
   try {
-    console.log("아이디 중복확인 API", loginId);
+    console.log("1) 아이디 중복확인 API", loginId);
     const response = await axios.get(`${USER_API}/check-loginId`, { params: { loginId } });  // 받은 loginId를 get사용 params 방식으로 전달
     // Query Parameter 형태로 변환. 즉, .../api/user/check-loginId?loginId=사용자입력값 형태로 요청이 전송됨
-    console.log("백엔드 응답 중복확인", response);
+    console.log("2) 백엔드 응답 중복확인", response);
     return response.data;
   } catch (error) {
-    console.log("중복확인 API 에러", error);
+    console.log("3 ) 중복확인 API 에러", error);
+    throw error;
+  }
+};
+
+//prettier-ignore
+export const getProfileApi = async (loginId) => {
+  try {
+    const response = await axios.get(`${USER_API}/profile`, { params: { loginId }});
+    console.log("1) 프로필 조회 API : ", response.data);
+    return response.data;
+  } catch (error) {
+    console.log("2) 프로필 조회 에러 : ", error);
+    throw error;
+  }
+};
+
+//prettier-ignore
+export const modifyProfileApi = async (modifyForm) => {
+  try{ 
+  console.log("1) 개인정보수정 출력", modifyForm);
+  const response = await axios.put(`${USER_API}/profile-modify`, modifyForm);
+  console.log("2) 개인정보수정 백엔드 응답 :", response.data);
+  return response.data;
+  } catch (error) {
+    console.log("3) 개인정보수정 API 에러", error);
     throw error;
   }
 };

--- a/src/components/user/signup/InfoStep.jsx
+++ b/src/components/user/signup/InfoStep.jsx
@@ -54,7 +54,7 @@ export default function InfoStep({ signUpForm, onChange, onPrev, onSubmit }) {
         ...signUpForm,
         postalCode: data.zonecode,
         address: data.address,
-        addressDetail: ""
+        addressDetail: "",
       });
     });
   };
@@ -243,7 +243,7 @@ export default function InfoStep({ signUpForm, onChange, onPrev, onSubmit }) {
               onChange={(e) =>
                 onChange({
                   ...signUpForm,
-                  phoneNumber: e.target.value.replace(/\D/g, "")
+                  phoneNumber: e.target.value.replace(/\D/g, ""),
                 })
               }
               placeholder="01012345678"
@@ -281,7 +281,7 @@ export default function InfoStep({ signUpForm, onChange, onPrev, onSubmit }) {
                 onChange={(e) =>
                   onChange({
                     ...signUpForm,
-                    birthY: e.target.value.replace(/\D/g, "")
+                    birthY: e.target.value.replace(/\D/g, ""),
                   })
                 }
                 className="h-11 px-3 rounded-md border focus:ring-2 focus:ring-emerald-600 text-sm"
@@ -294,7 +294,7 @@ export default function InfoStep({ signUpForm, onChange, onPrev, onSubmit }) {
                 onChange={(e) =>
                   onChange({
                     ...signUpForm,
-                    birthM: e.target.value.replace(/\D/g, "")
+                    birthM: e.target.value.replace(/\D/g, ""),
                   })
                 }
                 className="h-11 px-3 rounded-md border focus:ring-2 focus:ring-emerald-600 text-sm"
@@ -307,7 +307,7 @@ export default function InfoStep({ signUpForm, onChange, onPrev, onSubmit }) {
                 onChange={(e) =>
                   onChange({
                     ...signUpForm,
-                    birthD: e.target.value.replace(/\D/g, "")
+                    birthD: e.target.value.replace(/\D/g, ""),
                   })
                 }
                 className="h-11 px-3 rounded-md border focus:ring-2 focus:ring-emerald-600 text-sm"

--- a/src/components/user/util/formatPhoneNumber.js
+++ b/src/components/user/util/formatPhoneNumber.js
@@ -1,0 +1,12 @@
+export const formatPhoneNumber = (phoneNumber) => {
+  if (!phoneNumber) return "";
+  const numbers = phoneNumber.replace(/[^\d]/g, "");
+  if (numbers.length === 11) {
+    return numbers.replace(/(\d{3})(\d{4})(\d{4})/, "$1-$2-$3");
+  }
+  return phoneNumber;
+};
+
+export const unformatPhoneNumber = (phoneNumber) => {
+  return phoneNumber.replace(/[^\d]/g, "");
+};

--- a/src/components/user/util/validation.jsx
+++ b/src/components/user/util/validation.jsx
@@ -27,7 +27,7 @@ export const validate = (signUpForm) => { // 유효성 검사 함수
     if (!signUpForm.email || !/^\S+@\S+\.\S+$/.test(signUpForm.email))            e.email = "이메일 형식 오류";
 
     // 연락처 검사 로직
-    if (!signUpForm.phoneNumber || !/^\d{10,11}$/.test(signUpForm.phoneNumber))   e.phoneNumber = "휴대전화 숫자만 10~11자리 입력하세요.";
+    if (!signUpForm.phoneNumber || !/^\d{11}$/.test(signUpForm.phoneNumber))   e.phoneNumber = "휴대전화 숫자만 11자리 입력하세요.";
 
     // 우편번호 검사 로직
     if (!signUpForm.postalCode || !/^\d{5}$/.test(signUpForm.postalCode))         e.postalCode = "우편번호는 5자리 숫자입니다.";


### PR DESCRIPTION
- 개인정보조회 API 기능 추가
**로그인한 회원 정보 authSlice에 전역 상태로 관리하기**
유저정보가 필요하면 해당 Redux활용하면 다른곳에서도 정보사용 가능.
- authSlice 개인정보조회 Thunk 기능 구현하기
- ProfileForm(마이페이지 개인정보수정Component) 수정 가능한 form 만들기
   → 수정기능을 구현하려 했으나, 조회가 먼저 필요한 시점이여서 중간에 구현 해 놓았습니다.
- 다음주소API 적용하기
   → 해당 기능도 수정기능에서 구현했어야했지만, 조회 시점에서 구현하게 되었음.
- 로그인한 사용자만 접근할 수 있는 userEffcet 구현 후 주석 처리하기.
   → 테스트용
- handleSubmit 핸들러 기능 구현하기
   → 해당 기능도 수정기능에서 구현했어야했지만 조회 시점에서 구현하게 되었음. 이후 수정기능 구현 시 변경예정
- 백엔드 요청 및 응답 테스트 완료