### PR TITLE
[프론트] 상품 수정 컴포넌트 만들기 및 상품 수정 API - 버그수정

### DIFF
--- a/src/components/admin/product/modify/OptionRegistrationModify.jsx
+++ b/src/components/admin/product/modify/OptionRegistrationModify.jsx
@@ -68,7 +68,7 @@ function OptionRegistrationModify({ existingData, onChangeForm }) {
   const inputChangeHandler = (index, field, value) => {
     const updatedOptions = options.map((option, idx) =>
       // 수정한 옵션의 값만 바뀌도록
-      idx === index ? { ...option, [field]: value, type: "new" } : option
+      idx === index ? { ...option, [field]: value } : option
     );
     setOptions(updatedOptions);
     onChangeForm(updatedOptions);
@@ -77,7 +77,9 @@ function OptionRegistrationModify({ existingData, onChangeForm }) {
   const inputImgChangeHandler = (index, field, value) => {
     const updatedOptions = options.map((option, idx) =>
       // 수정한 옵션의 값만 바뀌도록
-      idx === index ? { ...option, [field]: value, imageUrl: null } : option
+      idx === index
+        ? { ...option, [field]: value, imageUrl: null, type: "new" }
+        : option
     );
     setOptions(updatedOptions);
     onChangeForm(updatedOptions);


### PR DESCRIPTION
-  옵션 객체의 type: "new" 는 해당 옵션의 이미지가 새로 들어온 이미지 파일인지를 판별하기 위한 값이다. 그런데 상품옵션의 이미지가 아니라 값을 수정할 때 옵션 객체의 type: "new" 를 넣었다.
해당 부분을 지우고 옵션 이미지가 교체 되었을 때 옵션객체에 type: "new" 를 추가하도록 함

This Closes #199 