### PR TITLE
[프론트] 유저 비밀번호 변경 기능 구현

### DIFF
--- a/src/api/user/userapi.js
+++ b/src/api/user/userapi.js
@@ -28,7 +28,7 @@ export const signUpApi = async (signUpForm) => {
       address: signUpForm.address, // 기본주소
       addressDetail: signUpForm.addressDetail, // 상세주소
       smsAgreement: signUpForm.smsAgreement, // SMS 알림 동의
-      emailAgreement: signUpForm.emailAgreement, // Email 알림 동의
+      emailAgreement: signUpForm.emailAgreement // Email 알림 동의
     };
 
     console.log("백엔드로 보내는 데이터 콘솔", requestData);
@@ -101,7 +101,11 @@ export const modifyProfileApi = async (modifyForm) => {
 
 //prettier-ignore
 export const changePasswordApi = async (passwordForm) => {
+  try{
   const response = await axios.patch(`${USER_API}/password-change`, passwordForm);
   console.log("1) 여기는 비밀번호변경 출력", passwordForm);
   return response.data;
+  } catch (error) {
+    throw error;
+  }
 };

--- a/src/components/user/login/LoginComponent.jsx
+++ b/src/components/user/login/LoginComponent.jsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   loginAsyncThunk,
-  clearError,
+  clearError
 } from "../../../redux/slices/features/user/authSlice";
 
 // prettier-ignore
@@ -45,7 +45,7 @@ const LoginComponent = () => {
 
   // prettier-ignore
   const loginHandleClick = () => { // 로그인핸들러
-    console.log("여기는 로그인컴포넌트 로그인클릭 실행되었다:", loginData); // 로그인 버튼 클릭 시 데이터 확인
+    console.log("여기는 로그인컴포넌트 로그인버튼이 클릭되었다:", loginData); // 로그인 버튼 클릭 시 데이터 확인
 
     if(!loginData.loginId.trim()) { // loginData의 loginId 공백제거 => 조건반대
       // 즉, 로그인아이디가 공백이라면, 입력되지 않았다면

--- a/src/components/user/mypage/PasswordChange.jsx
+++ b/src/components/user/mypage/PasswordChange.jsx
@@ -2,14 +2,14 @@ import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { changePasswordThunk } from "../../../redux/slices/features/user/authSlice";
 
-export default function PasswordChangeBox() {
+export default function PasswordChange() {
   const { user } = useSelector((state) => state.authSlice);
   const dispatch = useDispatch();
 
   const [pwForm, setPwForm] = useState({
     password: "",
     newPassword: "",
-    newPasswordConfirm: "",
+    newPasswordConfirm: ""
   });
 
   const handleChange = (e) => {
@@ -17,6 +17,7 @@ export default function PasswordChangeBox() {
     setPwForm((prev) => ({ ...prev, [name]: value }));
   };
 
+  //prettier-ignore
   const handleSubmit = async (e) => {
     e.preventDefault();
     console.log("현재 비밀번호 :", pwForm.password);
@@ -29,13 +30,12 @@ export default function PasswordChangeBox() {
       return;
     }
 
-    if (user && pwForm.password !== user.password) {
-      alert("비밀번호가 일치하지 않습니다.");
-      return;
-    }
-
     if (!pwForm.newPassword) {
       alert("새 비밀번호를 입력하세요.");
+      return;
+    }
+    if (!pwForm.newPasswordConfirm) {
+      alert("새 비밀번호를 확인을 입력하세요.");
       return;
     }
     if (pwForm.newPassword !== pwForm.newPasswordConfirm) {
@@ -47,20 +47,24 @@ export default function PasswordChangeBox() {
     try {
       const result = await dispatch(
         changePasswordThunk({
+          loginId: user.loginId,
           password: pwForm.password,
-          newPassword: pwForm.newPassword,
+          newPassword: pwForm.newPassword
         })
       ).unwrap();
+
+      console.log("여기는 Submit 반환결과 :", result)
+
       if (result.success) {
         alert(result.message);
         setPwForm({
           password: "",
-          newpassword: "",
-          newPasswordConfirm: "",
+          newPassword: "",
+          newPasswordConfirm: ""
         });
       }
     } catch (error) {
-      alert(error.message || "비밀번호 변경에 실패했습니다.");
+      alert(error.message);
     }
   };
 

--- a/src/components/user/mypage/ProfileForm.jsx
+++ b/src/components/user/mypage/ProfileForm.jsx
@@ -23,7 +23,7 @@ export default function ProfileForm() {
     addressDetail: profileData?.addressDetail || "",
     smsAgreement: profileData?.smsAgreement || false,
     emailAgreement: profileData?.emailAgreement || false,
-    password: "",
+    password: ""
   });
 
   // prettier-ignore
@@ -31,12 +31,12 @@ export default function ProfileForm() {
 
   // // 로그인한 사용자만 마이페이지 접근할 수 있는 로직 현재는 주석처리
   // useEffect(() => {
-  // if (!user) {
-  //   // navigate("/login");
-  //   return;
-  // }
-  // console.log("여기는 ProfileForm user 객체 확인 : ", user);
-  // console.log("여기는 ProfileForm user.loginid 확인", user.loginId);
+  //   if (!user) {
+  //     // navigate("/login");
+  //     return;
+  //   }
+  //   console.log("여기는 ProfileForm user 객체 확인 : ", user);
+  //   console.log("여기는 ProfileForm user.loginid 확인", user.loginId);
   //   dispatch(getUserProfileThunk(user.loginId))
   //     .unwrap()
   //     .then((profileData) => {
@@ -52,7 +52,7 @@ export default function ProfileForm() {
     const { name, value, type, checked } = e.target;
     setModifyForm((prev) => ({
       ...prev,
-      [name]: type === "checkbox" ? checked : value,
+      [name]: type === "checkbox" ? checked : value
     }));
   };
 
@@ -72,26 +72,21 @@ export default function ProfileForm() {
     const finalModifyData = {
       ...modifyForm,
       loginId: user.loginId,
-      phoneNumber: unformatPhoneNumber(modifyForm.phoneNumber),
+      phoneNumber: unformatPhoneNumber(modifyForm.phoneNumber)
     };
 
     try {
-      const response = await dispatch(
+      const result = await dispatch(
         modifyProfileThunk(finalModifyData)
       ).unwrap();
-
-      const result = response;
 
       console.log("profile update payload:", finalModifyData);
       console.log("여기는 result 확인용 로그 : ", result);
       if (result.success) {
-        alert(result.message || "개인정보 수정이 완료되었습니다.");
-      } else {
-        alert(result.message || "수정에 실패하였습니다.");
+        alert(result.message);
       }
     } catch (error) {
-      console.error("수정 오류:", error);
-      alert(error.message || "개인정보 수정이 실패 하였습니다.");
+      alert(error.message);
     }
   };
 
@@ -101,7 +96,7 @@ export default function ProfileForm() {
         ...modifyForm,
         postalCode: data.zonecode,
         address: data.address,
-        addressDetail: "",
+        addressDetail: ""
       });
     });
   };

--- a/src/redux/slices/features/user/authSlice.jsx
+++ b/src/redux/slices/features/user/authSlice.jsx
@@ -3,7 +3,7 @@ import {
   changePasswordApi,
   getProfileApi,
   loginApi,
-  modifyProfileApi,
+  modifyProfileApi
 } from "../../../../api/user/userApi";
 
 export const loginAsyncThunk = createAsyncThunk(
@@ -44,19 +44,19 @@ export const modifyProfileThunk = createAsyncThunk(
       const response = await modifyProfileApi(modifyData);
       return response;
     } catch (error) {
-      throw rejectWithValue(error.response.data || { message: "서버 오류" });
+      return rejectWithValue(error.response?.data || error.message);
     }
   }
 );
 
 export const changePasswordThunk = createAsyncThunk(
-  "auth/changPassword",
+  "auth/changePassword",
   async (changePasswordForm, { rejectWithValue }) => {
     try {
       const response = await changePasswordApi(changePasswordForm);
       return response;
     } catch (error) {
-      return rejectWithValue(error.message || { message: "서버 오류" });
+      return rejectWithValue(error.response?.data || "서버 오류");
     }
   }
 );
@@ -68,7 +68,7 @@ const initialState = {
   //Todo : token : null, JWT + Security 추가 후 진행 할 예정
   profile: null,
   error: null, // 에러 상태
-  loading: false, // 로딩 상태
+  loading: false // 로딩 상태
 };
 
 // prettier-ignore
@@ -160,15 +160,8 @@ export const authSlice = createSlice({// Slice 생성
         state.loading = true;
         state.error = null;
       })
-      .addCase(modifyProfileThunk.fulfilled, (state,action) => {
+      .addCase(modifyProfileThunk.fulfilled, (state) => {
         state.loading = false;
-        if (action.payload) {
-          if (action.payload.success && action.payload.updateProfile) {
-          state.profile = action.payload.updateProfile;
-          }
-        } else {
-          console.warn("프로필 수정 성공 응답을 받았으나, 응답 본문payload가 없음")
-        }
       })
       .addCase(modifyProfileThunk.rejected, (state,action) =>{
         state.loading = false;
@@ -176,11 +169,10 @@ export const authSlice = createSlice({// Slice 생성
       })
       .addCase(changePasswordThunk.pending, (state) => {
         state.loading = true;
-        error = null;
+        state.error = null;
       })
-      .addCase(changePasswordThunk.fulfilled, (state, action) => {
+      .addCase(changePasswordThunk.fulfilled, (state) => {
         state.loading = false;
-        error = null;
       })
       .addCase(changePasswordThunk.rejected, (state,action) => {
         state.loading = false;


### PR DESCRIPTION
- userApi → changePasswordApi 생성 (기능구현) 
- authSlice → changePasswordThunk 생성 (기능구현)
  ✅ changePasswordThunk → pending, fulfilled, rejected 구현
  ✅ modifyProfileApi → catch 리팩토링
  ✅ modifyProfileThunk → fulfilled 리팩토링 ( 백엔드 Http.Status 적용 )

※ 추가사항
- ProfileForm → 로그인한 사용자만 마이페이지 접근할 수 있는 로직 주석처리
- PasswordChangeBox → PasswordChange 이름변경
  ✅ 내부 Submit 핸들러 Thunk 처리로직 구현
  ✅ 내부 유효성검사 리팩토링
- Console.log 출력 및 디버깅 테스트
- 요청 및 응답 테스트 완료