### PR TITLE
[프론트] 사용자정보 Redux 리팩토링

### DIFF
--- a/src/components/user/login/LoginComponent.jsx
+++ b/src/components/user/login/LoginComponent.jsx
@@ -4,12 +4,14 @@ import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   loginAsyncThunk,
-  clearError
+  getUserProfileThunk,
+  clearError,
 } from "../../../redux/slices/features/user/authSlice";
 
 // prettier-ignore
 const LoginComponent = () => {
   const dispatch = useDispatch(); // Redux Dispatch 사용 함수
+  const navigate = useNavigate(); // useNaivate 경로Hook 
   const { isLoggedIn, error, loading } = useSelector( (state) => state.authSlice ); // 로그인상태, 에러상태, 로딩상태
 
   const [loginData, setLoginData] = useState({ // 로그인데이터 Form
@@ -17,7 +19,7 @@ const LoginComponent = () => {
     password: "", // 비밀번호
   });
 
-  const navigate = useNavigate(); // useNaivate 경로Hook 
+  
 
   const inputChangeHandler = (e) => { // 입력핸들러
     const { name, value } = e.target; // 이벤트객체 target 속성 name과 value 디스럭처링
@@ -36,7 +38,7 @@ const LoginComponent = () => {
   }, [isLoggedIn, navigate]);
 
   useEffect(() => { // useEffect Hook
-    if (error) { // error true ?
+    if (error) { // error true 
       alert(`로그인 실패: ${error}`); // 알림 + error
       dispatch(clearError()); // clearError authSlice 호출
     }
@@ -58,7 +60,19 @@ const LoginComponent = () => {
       return;
     }
     
-    dispatch( loginAsyncThunk(loginData) ); // loginAsyncThunk Reducer 호출 해당 loginData 인자 전달
+    dispatch(loginAsyncThunk(loginData)).unwrap()
+    .then(loginResult => { 
+        const loginId = loginResult.loginId || loginData.loginId;
+        if(loginId) {
+          dispatch(getUserProfileThunk(loginId))
+          .catch(profileError => {
+            console.log("로그인 성공 후 프로필 조회 실패", profileError)
+          });
+      }
+    })
+    .catch(err => {
+      console.error("로그인 Thunk rejected", err)
+    })
     console.log(`로그인 버튼이 눌렸습니다. \n 이메일: ${loginData.loginId} \n 비밀번호: ${loginData.password}`);
   };
 

--- a/src/components/user/mypage/ProfileForm.jsx
+++ b/src/components/user/mypage/ProfileForm.jsx
@@ -8,7 +8,7 @@ import {  authSlice,  getUserProfileThunk,  modifyProfileThunk } from "../../../
 import {  formatPhoneNumber,  unformatPhoneNumber } from "../util/formatPhoneNumber.js";
 
 export default function ProfileForm() {
-  const { user } = useSelector((state) => state.authSlice);
+  const { user, profile } = useSelector((state) => state.authSlice);
   const { openPostcode } = useDaumPostalCode(); // 다음주소API
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -23,36 +23,24 @@ export default function ProfileForm() {
     addressDetail: profileData?.addressDetail || "",
     smsAgreement: profileData?.smsAgreement || false,
     emailAgreement: profileData?.emailAgreement || false,
-    password: ""
+    password: "",
   });
 
   // prettier-ignore
-  const [modifyForm, setModifyForm] = useState(initializeForm(null));
+  const [modifyForm, setModifyForm] = useState(initializeForm(profile));
 
-  // // 로그인한 사용자만 마이페이지 접근할 수 있는 로직 현재는 주석처리
-  // useEffect(() => {
-  //   if (!user) {
-  //     // navigate("/login");
-  //     return;
-  //   }
-  //   console.log("여기는 ProfileForm user 객체 확인 : ", user);
-  //   console.log("여기는 ProfileForm user.loginid 확인", user.loginId);
-  //   dispatch(getUserProfileThunk(user.loginId))
-  //     .unwrap()
-  //     .then((profileData) => {
-  //       console.log("여기는 unwrap Promise then 결과 확인 :", profileData);
-  //       setModifyForm(initializeForm(profileData));
-  //     })
-  //     .catch((err) => {
-  //       console.error("여기는 then 데이터 결과 프로필 조회 실패:", err);
-  //     });
-  // }, [user?.loginId, navigate, dispatch]);
+  useEffect(() => {
+    if (profile) {
+      setModifyForm(initializeForm(profile));
+      console.log("ProfileForm: Redux profile 데이터 폼 상태 갱신 완료");
+    }
+  }, [profile]);
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target;
     setModifyForm((prev) => ({
       ...prev,
-      [name]: type === "checkbox" ? checked : value
+      [name]: type === "checkbox" ? checked : value,
     }));
   };
 
@@ -72,7 +60,7 @@ export default function ProfileForm() {
     const finalModifyData = {
       ...modifyForm,
       loginId: user.loginId,
-      phoneNumber: unformatPhoneNumber(modifyForm.phoneNumber)
+      phoneNumber: unformatPhoneNumber(modifyForm.phoneNumber),
     };
 
     try {
@@ -96,7 +84,7 @@ export default function ProfileForm() {
         ...modifyForm,
         postalCode: data.zonecode,
         address: data.address,
-        addressDetail: ""
+        addressDetail: "",
       });
     });
   };

--- a/src/redux/slices/features/user/authSlice.jsx
+++ b/src/redux/slices/features/user/authSlice.jsx
@@ -3,7 +3,7 @@ import {
   changePasswordApi,
   getProfileApi,
   loginApi,
-  modifyProfileApi
+  modifyProfileApi,
 } from "../../../../api/user/userApi";
 
 export const loginAsyncThunk = createAsyncThunk(
@@ -68,7 +68,7 @@ const initialState = {
   //Todo : token : null, JWT + Security 추가 후 진행 할 예정
   profile: null,
   error: null, // 에러 상태
-  loading: false // 로딩 상태
+  loading: false, // 로딩 상태
 };
 
 // prettier-ignore
@@ -160,8 +160,9 @@ export const authSlice = createSlice({// Slice 생성
         state.loading = true;
         state.error = null;
       })
-      .addCase(modifyProfileThunk.fulfilled, (state) => {
+      .addCase(modifyProfileThunk.fulfilled, (state, action) => {
         state.loading = false;
+        state.profile = action.payload;
       })
       .addCase(modifyProfileThunk.rejected, (state,action) =>{
         state.loading = false;


### PR DESCRIPTION
- 로그인 시 프로필까지 Redux State 관리 되도록 변경
- (기존) ProfileForm → 해당 페이지 접근 시 조회Reducer 실행
- (변경) ProfileForm → Redux Sate 불러와서 바로 조회 가능
- 로그인슬라이스 개인정보수정 fulfilled sate.profile 추가