### PR TITLE
리덕스 authSlice 변경

### DIFF
--- a/src/redux/slices/features/user/authSlice.jsx
+++ b/src/redux/slices/features/user/authSlice.jsx
@@ -160,9 +160,8 @@ export const authSlice = createSlice({// Slice 생성
         state.loading = true;
         state.error = null;
       })
-      .addCase(modifyProfileThunk.fulfilled, (state, action) => {
+      .addCase(modifyProfileThunk.fulfilled, (state) => {
         state.loading = false;
-        state.profile = action.payload;
       })
       .addCase(modifyProfileThunk.rejected, (state,action) =>{
         state.loading = false;


### PR DESCRIPTION
- modifyProfileThunk.fulfilled → action 삭제
- action.payload 초기화 실수 정상화완료