### PR TITLE
[프론트] 상품 상세 페이지에 장바구니, 바로구매 버튼 기능 구현, 결제 페이지 포인트 기능 구현중, 결제 페이지 오류 수정

### DIFF
--- a/src/api/point/pointApi.js
+++ b/src/api/point/pointApi.js
@@ -1,0 +1,10 @@
+import axios from "axios";
+
+const API_SERVER_HOST = "http://localhost:8080";
+const prefix = `${API_SERVER_HOST}/api/point`;
+
+export const getActivePoints = async (userId) => {
+  const res = await axios.get(`${prefix}/${userId}`);
+  console.log("getActivePoints 백엔드로 부터 받은 데이터=> ", res.data);
+  return res.data;
+};

--- a/src/components/order/CouponModal.jsx
+++ b/src/components/order/CouponModal.jsx
@@ -15,7 +15,7 @@ const CouponModal = ({ onClose, onSelect, userId, totalPrice }) => {
   }, []);
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center">
+    <div className="fixed inset-0 bg-black/40 flex justify-center items-center">
       <div className="bg-white rounded-lg p-6 w-80 shadow">
         <h3 className="font-semibold text-lg mb-4">보유 쿠폰</h3>
 

--- a/src/components/orderhistory/CancleModal.jsx
+++ b/src/components/orderhistory/CancleModal.jsx
@@ -1,6 +1,6 @@
 export default function CancelModal({ item, closeModal }) {
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center z-50">
+    <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-50">
       <div className="bg-white w-96 rounded-lg p-6">
         <h2 className="text-lg font-bold mb-4">취소 신청</h2>
 

--- a/src/components/orderhistory/ConfimPurchaseModal.jsx
+++ b/src/components/orderhistory/ConfimPurchaseModal.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+const ConfimPurchaseModal = ({ order, closeModal }) => {
+  console.log("order", order);
+
+  return <div>ConfimPurchaseModal</div>;
+};
+
+export default ConfimPurchaseModal;

--- a/src/components/orderhistory/DeliveryModal.jsx
+++ b/src/components/orderhistory/DeliveryModal.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const DeliveryModal = ({ item, closeModal }) => {
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center z-50">
+    <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-50">
       <div className="bg-white p-6 rounded-lg shadow-lg w-96 text-center">
         <h2 className="text-lg font-bold mb-4">배송 조회</h2>
         <p className="text-sm text-gray-600 mb-3">{item.pname}</p>

--- a/src/components/orderhistory/ExchangeModal.jsx
+++ b/src/components/orderhistory/ExchangeModal.jsx
@@ -1,6 +1,6 @@
 export default function ExchangeModal({ item, closeModal }) {
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center z-50">
+    <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-50">
       <div className="bg-white w-96 rounded-lg p-6">
         <h2 className="text-lg font-bold mb-4">교환 신청</h2>
 

--- a/src/components/orderhistory/OrderHistoryComponent.jsx
+++ b/src/components/orderhistory/OrderHistoryComponent.jsx
@@ -7,6 +7,7 @@ import ExchangeModal from "./ExchangeModal";
 import sampleOrders from "../../data/sampleOrders";
 import { getOrderList } from "../../api/order/orderApi";
 import { useSelector } from "react-redux";
+import ConfimPurchaseModal from "./ConfimPurchaseModal";
 
 export default function OrderHistoryComponent() {
   const { user } = useSelector((state) => state.authSlice);
@@ -28,6 +29,10 @@ export default function OrderHistoryComponent() {
 
   // 배송 조회 모달
   const [deliveryModal, setDeliveryModal] = useState(false);
+  // 구매 확정 모달
+  const [confirmPurchaseModal, setConfirmPurchaseModal] = useState(false);
+  // 구매 확정 모달에 전달되는 주문 정보
+  const [selectedOrder, setSelectedOrder] = useState({});
   // 취소 신청 모달
   const [cancleModal, setCancleModal] = useState(false);
   // 반품 신청 모달
@@ -344,6 +349,19 @@ export default function OrderHistoryComponent() {
                           <div className="text-xs text-gray-400">
                             {order.orderNumber}
                           </div>
+                          {orderStatusMap[item.orderProductStatus] ===
+                            "배송완료" && (
+                            <button
+                              className="text-xs px-3 py-1 border bg-black text-white hover:bg-gray-800 transition-colors w-full"
+                              onClick={() => {
+                                setConfirmPurchaseModal(true);
+                                setSelectedOrder(order);
+                                console.log(selectedOrder);
+                              }}
+                            >
+                              구매 확정
+                            </button>
+                          )}
                         </td>
                       )}
 
@@ -424,7 +442,7 @@ export default function OrderHistoryComponent() {
                               취소신청
                             </button>
                           )}
-                          {orderStatusMap[item.orderProductStatus] !==
+                          {orderStatusMap[item.orderProductStatus] ===
                             "배송완료" && (
                             <button
                               className="text-xs px-3 py-1 border border-gray-300 hover:bg-gray-50 transition-colors w-full"
@@ -535,6 +553,12 @@ export default function OrderHistoryComponent() {
         <ExchangeModal
           item={selectedItem}
           closeModal={() => setExchangeModal(false)}
+        />
+      )}
+      {confirmPurchaseModal && selectedItem && (
+        <ConfimPurchaseModal
+          order={selectedOrder}
+          closeModal={() => setConfirmPurchaseModal(false)}
         />
       )}
     </div>

--- a/src/components/orderhistory/ReturnModal.jsx
+++ b/src/components/orderhistory/ReturnModal.jsx
@@ -1,6 +1,6 @@
 export default function ReturnModal({ item, closeModal }) {
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center z-50">
+    <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-50">
       <div className="bg-white w-96 rounded-lg p-6">
         <h2 className="text-lg font-bold mb-4">반품 신청</h2>
 


### PR DESCRIPTION
- 상품 상세 페이지 장바구니, 바로구매 버튼 기능 구현
- ProductDetailComponent에서 필요 없는 코드 삭제
- 포인트 기능 구현중 -> pointApi.js 추가(백엔드와 통신하여 사용 가능한 포인트 조회)
-> OrderComponent에서 사용 가능한 포인트 조회하도록 구현
- 쿠폰 오류 수정 -> 쿠폰을 선택하지 않았을 때 결제가 안 되는 오류 수정
- 주문 내역 페이지에서 구매 확정 버튼 누르면 구매 확정 모달창 뜨면서 포인트 적립하도록 기능 구현 중
- 모달창 뜰 때 검은 화면으로 보이는 것 수정(연하게 화면이 보이도록 수정)