### PR TITLE
[프론트] 주문 내역 페이지에서 구매 확정 누르면 포인트 적립되도록 설계

### DIFF
--- a/src/api/order/orderApi.js
+++ b/src/api/order/orderApi.js
@@ -34,3 +34,9 @@ export const getOrdersBySearch = async (condition) => {
   // console.log("getOrdersBySearch => ", res.data);
   return res.data;
 };
+
+export const confirmOrder = async (orderId) => {
+  const res = await axios.put(`${prefix}/confirm/${orderId}`);
+  console.log("confirmOrder =>", res.data);
+  return res.data;
+};

--- a/src/api/point/pointApi.js
+++ b/src/api/point/pointApi.js
@@ -5,6 +5,12 @@ const prefix = `${API_SERVER_HOST}/api/point`;
 
 export const getActivePoints = async (userId) => {
   const res = await axios.get(`${prefix}/${userId}`);
-  console.log("getActivePoints 백엔드로 부터 받은 데이터=> ", res.data);
+  // console.log("getActivePoints 백엔드로 부터 받은 데이터=> ", res.data);
+  return res.data;
+};
+
+export const earnPoint = async (dto) => {
+  const res = await axios.post(`${prefix}/earn`, dto);
+  console.log("earnPoint 백엔드로부터 받은 데이터 => ", res.data);
   return res.data;
 };

--- a/src/components/orderhistory/ConfimPurchaseModal.jsx
+++ b/src/components/orderhistory/ConfimPurchaseModal.jsx
@@ -1,9 +1,83 @@
 import React from "react";
 
-const ConfimPurchaseModal = ({ order, closeModal }) => {
-  console.log("order", order);
+const ConfimPurchaseModal = ({ order, userId, closeModal, onConfirm }) => {
+  // order.earnedPoints를 사용하여 적립 포인트를 표시합니다.
+  const earnedPoints = order?.earnedPoints || "0원"; // order나 earnedPoints가 없을 경우 '0원'으로 기본값 설정
 
-  return <div>ConfimPurchaseModal</div>;
+  return (
+    <div className="fixed inset-0 bg-black/50 flex justify-center items-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full overflow-hidden">
+        {/* 모달 헤더 */}
+        <div className="p-5 border-b border-gray-100">
+          <h2 className="text-xl font-bold text-gray-800">✅ 구매 확정하기</h2>
+        </div>
+
+        {/* 모달 내용 */}
+        <div className="p-6 space-y-5">
+          {/* 적립 포인트 정보 섹션 */}
+          <div className="bg-orange-50 p-4 rounded-lg text-center border-2 border-orange-300">
+            <h3 className="text-md font-semibold text-orange-700 mb-2">
+              구매 확정 시 적립되는 포인트
+            </h3>
+            <p className="text-3xl font-extrabold text-orange-600">
+              {earnedPoints}
+            </p>
+            <p className="text-sm text-orange-700 mt-1">
+              포인트가 즉시 적립됩니다.
+            </p>
+          </div>
+
+          {/* 구매 확정 정의 섹션 */}
+          <div className="bg-gray-50 p-4 rounded-lg">
+            <h3 className="font-semibold text-lg text-gray-700 mb-2">
+              구매 확정이란?
+            </h3>
+            <p className="text-sm text-gray-600 leading-relaxed">
+              상품을 받거나 서비스를 제공받은 후, **반품이나 교환 없이 구매를
+              최종적으로 확인**하는 고객님의 의사 표시입니다.
+            </p>
+          </div>
+
+          {/* 중요 경고 섹션 (반품/교환 불가) */}
+          <div className="p-4 border border-red-300 bg-red-50 rounded-lg">
+            <p className="font-bold text-red-600 flex items-center">
+              <span className="text-xl mr-2">⚠️</span> 중요 안내
+            </p>
+            <p className="text-sm text-red-700 mt-1">
+              **구매 확정 이후에는 반품/교환 신청이 불가**하오니, 상품을 충분히
+              확인하신 후 진행해 주세요.
+            </p>
+          </div>
+
+          {/* 최종 확인 문구 */}
+          <p className="text-md font-medium text-center text-gray-800 pt-2">
+            위 내용을 확인하셨다면, **구매를 확정**하시겠습니까?
+          </p>
+        </div>
+
+        {/* 모달 푸터 (버튼 영역) */}
+        <div className="flex justify-end gap-3 p-5 border-t border-gray-100 bg-white sticky bottom-0">
+          <button
+            className="px-6 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-100 transition duration-150 ease-in-out font-medium"
+            onClick={closeModal}
+          >
+            닫기
+          </button>
+
+          <button
+            className="px-6 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 transition duration-150 ease-in-out font-semibold shadow-md shadow-orange-200"
+            onClick={() => {
+              // 구매 확정 로직 호출
+              onConfirm(userId, order);
+              closeModal();
+            }}
+          >
+            구매 확정
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default ConfimPurchaseModal;

--- a/src/components/orderhistory/ConfirmPurchaseCompleteModal.jsx
+++ b/src/components/orderhistory/ConfirmPurchaseCompleteModal.jsx
@@ -1,0 +1,44 @@
+// ConfirmPurchaseCompleteModal.jsx
+import React from "react";
+
+const ConfirmPurchaseCompleteModal = ({ order, totalPoints, closeModal }) => {
+  const earnedPoints = order.earnedPoints;
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-50">
+      <div className="bg-white p-6 rounded-lg shadow-2xl w-96 text-center max-w-sm mx-auto relative">
+        {/* 닫기 버튼 */}
+        <button
+          className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 text-2xl"
+          onClick={closeModal}
+        >
+          &times;
+        </button>
+
+        <h2 className="text-xl font-bold mb-6 mt-4">구매확정 완료</h2>
+
+        {/* 적립 포인트 정보 */}
+        <div className="mb-8">
+          <p className="text-3xl font-bold text-orange-600 mb-2">
+            +{earnedPoints.toLocaleString()}원 적립되었습니다.
+          </p>
+          <div className="inline-block bg-gray-100 p-2 rounded-full mt-4">
+            <span className="text-sm font-medium">내 포인트 잔액</span>
+            <span className="text-lg font-extrabold ml-2">
+              {totalPoints.toLocaleString()}원
+            </span>
+          </div>
+        </div>
+
+        <button
+          className="w-full px-4 py-3 bg-orange-500 text-white font-semibold rounded-lg hover:bg-orange-600 transition-colors"
+          onClick={closeModal}
+        >
+          확인
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmPurchaseCompleteModal;


### PR DESCRIPTION
- 주문 내역 페이지에서 구매 확정 누르면 포인트 적립 되도록 설계 ->
1. orderApi에 주문 상태 'CONFIRMED'로 바꾸는 API 호출
2. pointApi에 포인트 적립하는 api 호출
3. 구매 확정 모달 구현 완료
4. 구매 확정 완료 모달 추가
5. OrderHistoryComponent에 구매 확정 눌렀을때 발생하는 함수와 모달 컴포넌트 추가(구매 확정을 눌렀을 때 주문 상품의 주문 상태가 모두 구매 확정으로 바뀌고 마지막에 구매 확정 완료 모달이 뜨도록 설계하였습니다.)