### PR TITLE
[프론트] 주문 내역 페이지 주문 취소 기능 구현

### DIFF
--- a/src/components/order/CouponModal.jsx
+++ b/src/components/order/CouponModal.jsx
@@ -14,10 +14,13 @@ const CouponModal = ({ onClose, onSelect, userId, totalPrice }) => {
     fetchCoupons();
   }, []);
 
+  // console.log("coupons", coupons);
+
   return (
     <div className="fixed inset-0 bg-black/40 flex justify-center items-center">
       <div className="bg-white rounded-lg p-6 w-80 shadow">
         <h3 className="font-semibold text-lg mb-4">보유 쿠폰</h3>
+        {coupons.length == 0 && <h2>보유한 쿠폰이 없습니다.</h2>}
 
         {coupons &&
           coupons.map((coupon) => {

--- a/src/components/order/OrderComponent.jsx
+++ b/src/components/order/OrderComponent.jsx
@@ -227,33 +227,16 @@ const OrderComponent = () => {
       // SDK 초기화
       IMP.init("imp62835818");
 
-      // 테스트 모드 플래그 추가
-      const IS_TEST_MODE = true; // 프로덕션 배포시 false로 변경
-
       // 결제 수단에 따른 PG 및 pay_method 매핑
       const getPgCode = (method) => {
-        //테스트 모드일 때
-        if (IS_TEST_MODE) {
-          // ⭐ 테스트 모드 - 자정에 자동 취소되는 PG사 사용
-          const testPgMap = {
-            card: "html5_inicis.INIpayTest", // KG이니시스 테스트 (자동취소)
-            kakao: "kakaopay.TC0ONETIME", // 카카오페이 테스트
-            payco: "payco.PARTNERTEST", // 페이코 테스트
-            phone: "danal.A010002002", // 다날 테스트 (자동취소)
-            bank: "html5_inicis.INIpayTest", // 계좌이체 테스트
-          };
-          return testPgMap[method];
-        } else {
-          // 실제 운영 모드일 때
-          const pgMap = {
-            card: "nice.iamport00m",
-            kakao: "kakaopay.TC0ONETIME",
-            payco: "payco.PARTNERTEST",
-            phone: "nice.iamport00m",
-            bank: "nice.iamport00m",
-          };
-          return pgMap[method];
-        }
+        const pgMap = {
+          card: "html5_inicis.INIpayTest", // KG이니시스 테스트 (자동취소)
+          kakao: "kakaopay.TC0ONETIME", // 카카오페이 테스트
+          payco: "payco.PARTNERTEST", // 페이코 테스트
+          phone: "danal.A010002002", // 다날 테스트 (자동취소)
+          bank: "html5_inicis.INIpayTest", // 계좌이체 테스트
+        };
+        return pgMap[method];
       };
 
       const getPayMethod = (method) => {
@@ -278,7 +261,6 @@ const OrderComponent = () => {
               ? `${cartItems[0].productName} 외 ${cartItems.length - 1}건`
               : cartItems[0].productName,
 
-          // 테스트 모드일 때는 안전한 금액 사용
           amount: serverFinalAmount, // 최종 결제 금액
           buyer_email: "user@example.com", //실제 사용자 이메일로 변경 필요
           buyer_name: receiverName,
@@ -289,8 +271,7 @@ const OrderComponent = () => {
         async (response) => {
           console.log("결제 응답:", response);
           if (response.success === false) {
-            const result = await deleteOneOrder(resultOrderId);
-            console.log("백엔드 통신 결과", result);
+            setSelectedCoupon(null);
             return alert(
               `결제에 실패하였습니다. 에러 내용: ${response.error_msg}`
             );
@@ -635,7 +616,7 @@ const OrderComponent = () => {
                         적용된 쿠폰: {couponName}
                       </span>
                     ) : (
-                      "사용 가능한 쿠폰 1개"
+                      "사용 가능한 쿠폰 "
                     )}
                   </span>
                   <button

--- a/src/components/orderhistory/CancleModal.jsx
+++ b/src/components/orderhistory/CancleModal.jsx
@@ -1,25 +1,89 @@
-export default function CancelModal({ item, closeModal }) {
+export default function CancelModal({
+  selectedOrder,
+  item,
+  onConfirm,
+  closeModal,
+}) {
+  // orderProductGroup: 해당 주문 번호에 묶인 전체 상품 리스트 (배열)
+  const totalItemsCount = selectedOrder.orderProducts?.length || 1;
+  const isMultiple = totalItemsCount > 1;
+
+  console.log("item", item);
+  console.log("selectedOrder", selectedOrder);
+  console.log("orderProducts", selectedOrder.orderProducts);
+
   return (
-    <div className="fixed inset-0 bg-black/40 flex justify-center items-center z-50">
-      <div className="bg-white w-96 rounded-lg p-6">
-        <h2 className="text-lg font-bold mb-4">취소 신청</h2>
+    <div className="fixed inset-0 bg-black/60 flex justify-center items-center z-50 p-4">
+      <div className="bg-white w-full max-w-md rounded-2xl shadow-xl overflow-hidden animate-in fade-in zoom-in duration-200">
+        {/* 경고 헤더 */}
+        <div className="p-6 text-center border-b border-gray-50">
+          <div className="w-12 h-12 bg-red-100 text-red-600 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.34c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
+              />
+            </svg>
+          </div>
+          <h2 className="text-xl font-bold text-gray-900">
+            주문 전체 취소 안내
+          </h2>
+        </div>
 
-        <p className="text-sm text-gray-600 mb-2">{item.pname}</p>
+        {/* 본문 내용 */}
+        <div className="p-6">
+          <p className="text-gray-600 text-sm mb-4 leading-relaxed">
+            고객님, 본 주문은 묶음 결제된 상품으로{" "}
+            <span className="font-bold text-red-600">부분 취소가 불가능</span>
+            합니다. 취소 시 아래 상품을 포함한 주문 건 전체가 취소됩니다.
+          </p>
 
-        <textarea
-          className="w-full border rounded p-2 text-sm"
-          placeholder="취소 사유를 입력해주세요."
-        />
+          <div className="bg-gray-50 rounded-lg p-4 border border-gray-100">
+            <div className="flex items-start gap-3">
+              <img
+                src={item.imageUrl}
+                alt={item.productName}
+                className="w-12 h-12 rounded object-cover border"
+              />
+              <div>
+                <p className="text-sm font-medium text-gray-800 line-clamp-1">
+                  {item.productName} - {item.productOptionName}
+                </p>
+                {isMultiple && (
+                  <p className="text-xs text-blue-600 mt-1 font-semibold">
+                    외 {totalItemsCount - 1}건의 상품이 함께 취소됩니다.
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
 
-        <div className="flex justify-end gap-2 mt-4">
-          <button className="px-4 py-2 border rounded" onClick={closeModal}>
-            닫기
-          </button>
+          <p className="text-[12px] text-gray-400 mt-4 text-center">
+            취소 완료 후, 필요한 상품만 장바구니에 담아 다시 결제해 주세요.
+          </p>
+        </div>
+
+        {/* 하단 버튼 */}
+        <div className="flex gap-2 p-4 bg-gray-50">
           <button
-            className="px-4 py-2 bg-[#111] text-white rounded"
+            className="flex-1 py-3 text-sm font-semibold text-gray-500 bg-white border border-gray-200 rounded-xl hover:bg-gray-50 transition-colors"
             onClick={closeModal}
           >
-            취소 요청
+            돌아가기
+          </button>
+          <button
+            className="flex-1 py-3 text-sm font-semibold text-white bg-[#111] rounded-xl hover:bg-black transition-colors shadow-lg shadow-black/10"
+            onClick={() => onConfirm(selectedOrder.id)}
+          >
+            전체 취소하기
           </button>
         </div>
       </div>

--- a/src/components/orderhistory/OrderHistoryComponent.jsx
+++ b/src/components/orderhistory/OrderHistoryComponent.jsx
@@ -55,7 +55,7 @@ export default function OrderHistoryComponent() {
   const [deliveryModal, setDeliveryModal] = useState(false);
   // 구매 확정 모달
   const [confirmPurchaseModal, setConfirmPurchaseModal] = useState(false);
-  // 구매 확정 모달에 전달되는 주문 정보
+  // 구매 확정 모달, 취소 신청 모달에 전달되는 주문 정보
   const [selectedOrder, setSelectedOrder] = useState({});
   // 구매 확정 완료 모달
   const [confirmPurchaseCompleteModal, setConfirmPurchaseCompleteModal] =
@@ -66,8 +66,7 @@ export default function OrderHistoryComponent() {
 
   // 취소 신청 모달
   const [cancleModal, setCancleModal] = useState(false);
-  // 취소 신청 모달에 쓰이는 주문 상품 그룹
-  const [orderProductGroup, setOrderProductGroup] = useState([]);
+
   // 반품 신청 모달
   const [returnModal, setReturnModal] = useState(false);
   // 교환 신청 모달
@@ -253,6 +252,17 @@ export default function OrderHistoryComponent() {
   const handleConfirmCancel = async (orderId) => {
     const result = await deleteOneOrder(orderId);
     console.log("deleteOneOrder result", result);
+
+    // 서버 요청이 성공적이라면 (보통 result가 존재하거나 성공 코드를 반환할 때)
+    // 화면의 orderList 상태에서 방금 취소한 orderId를 가진 주문만 제외시킵니다.
+    setOrderList((prevList) =>
+      prevList.filter((order) => order.id !== orderId)
+    );
+
+    setCancleModal(false);
+
+    // (선택사항) 사용자 피드백
+    alert("주문이 성공적으로 취소되었습니다.");
   };
 
   return (
@@ -535,7 +545,7 @@ export default function OrderHistoryComponent() {
                               onClick={() => {
                                 setCancleModal(!cancleModal);
                                 setSelectedItem(item);
-                                setOrderProductGroup(order.orderProducts);
+                                setSelectedOrder(order);
                               }}
                             >
                               취소신청
@@ -598,11 +608,11 @@ export default function OrderHistoryComponent() {
           closeModal={() => setReturnModal(false)}
         />
       )}
-      {cancleModal && selectedItem && (
+      {cancleModal && selectedOrder && selectedItem && (
         <CancleModal
+          selectedOrder={selectedOrder}
           item={selectedItem}
           closeModal={() => setCancleModal(false)}
-          orderProductGroup={orderProductGroup}
           onConfirm={handleConfirmCancel}
         />
       )}


### PR DESCRIPTION
- 주문 내역 페이지 주문 취소 기능 구현
1. 취소 신청 모달 수정(디자인, 텍스트 등 변경)
2. 취소 신청 후 브라우저에 취소된 주문은 화면에서 지워지도록 프론트 수정
- OrderComponent에서 PG Code 하나로 통일(테스트 모드일 때와 실제 운영 모드일 때 PG code가 달랐는데 testPgMap을 pgMap으로 바꾸고 기존에 있던 실제 운영 모드에서의 PG Code Map은 삭제)