### PR TITLE
[프론트] 관리자 페이지 주문 상태 변경 모달 추가, 초기화 버튼 누를 시 체크박스 전체 체크로 변경

### DIFF
--- a/src/components/admin/order/AdminOrderMgrComponent.jsx
+++ b/src/components/admin/order/AdminOrderMgrComponent.jsx
@@ -173,9 +173,27 @@ const AdminOrderMgrComponent = () => {
     setProductName("");
     setStartDate("");
     setEndDate("");
-    setSelectedOrderStatuses([]);
+    setSelectedOrderStatuses([
+      "전체",
+      "주문접수",
+      "결제완료",
+      "배송준비중",
+      "배송중",
+      "배송완료",
+      "구매확정",
+      "반품/환불 신청",
+      "반품/환불 완료",
+    ]);
     setSelectedDelivery([]);
-    setSelectedPayment([]);
+    setSelectedPayment([
+      "전체",
+      "신용/체크카드",
+      "카카오페이",
+      "네이버페이",
+      "PAYCO",
+      "휴대폰 결제",
+      "계좌이체",
+    ]);
   };
 
   return (
@@ -237,7 +255,7 @@ const AdminOrderMgrComponent = () => {
           <div className="p-2 flex items-center flex-wrap flex-grow gap-x-3">
             <select className="border border-gray-300 p-1 mr-2 bg-white cursor-pointer h-[32px] rounded-md focus:ring-blue-500 focus:border-blue-500 transition">
               <option>주문일</option>
-              <option>결제일</option>
+              {/* <option>결제일</option> */}
             </select>
             <div className="flex items-center gap-1">
               <input

--- a/src/components/admin/order/ConfirmModal.jsx
+++ b/src/components/admin/order/ConfirmModal.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+
+const ConfirmModal = ({
+  confirmModalData,
+  requestStatus,
+  onConfirm,
+  onClose,
+}) => {
+  const getOrderStatusName = (status) => {
+    switch (status) {
+      case "PENDING_PAYMENT":
+        return "주문접수";
+      case "PAID":
+        return "결제완료";
+      case "PREPARING":
+        return "배송준비중";
+      case "SHIPPING":
+        return "배송중";
+      case "DELIVERED":
+        return "배송완료";
+      case "RETURN_REQUESTED":
+        return "반품/환불 신청";
+      case "RETURNED":
+        return "반품/환불 완료";
+      default:
+        return status; // 정의되지 않은 상태는 그대로 반환
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-white rounded-lg shadow-xl p-6 w-[22rem]">
+        <h3 className="text-lg font-bold mb-4 text-gray-800 flex items-center gap-2">
+          <span className="text-orange-500">⚠️</span> 상태 변경 확인
+        </h3>
+
+        <div className="space-y-3 mb-6">
+          <p className="text-gray-600">
+            주문 상태를{" "}
+            <span className="font-bold text-blue-600 underline underline-offset-4">
+              [{getOrderStatusName(requestStatus)}]
+            </span>
+            (으)로 변경하시겠습니까?
+          </p>
+
+          {/* 강조 문구 구역 */}
+          <div className="bg-orange-50 border-l-4 border-orange-400 p-3">
+            <p className="text-sm text-orange-800 leading-relaxed">
+              <strong>안내:</strong> 이 변경은 해당 주문(번호:{" "}
+              {confirmModalData?.orderNumber})에 포함된
+              <span className="font-bold text-orange-600">
+                {" "}
+                모든 상품의 상태
+              </span>
+              에 동일하게 적용됩니다.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={() => onClose()}
+            className="px-4 py-2 bg-gray-100 text-gray-700 rounded-md hover:bg-gray-200 font-medium transition"
+          >
+            취소
+          </button>
+          <button
+            onClick={() => onConfirm(confirmModalData, requestStatus)}
+            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 font-medium shadow-sm transition"
+          >
+            변경하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/admin/order/OrderSearchResultTable.jsx
+++ b/src/components/admin/order/OrderSearchResultTable.jsx
@@ -1,11 +1,19 @@
 import React, { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { changeOrderProductStatus } from "../../../api/order/orderApi";
+import ConfirmModal from "./ConfirmModal";
 
 const OrderSearchResultTable = ({ orders, searchHandler }) => {
   // console.log("orders", orders);
 
   const [searchParams, setSearchParams] = useSearchParams();
+
+  // 상태 변경 모달창
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  // 상태 변경 모달창에 전달하는 주문 상품 item
+  const [confirmModalData, setConfirmModalData] = useState({});
+  // 상태 변경 요청할 상태
+  const [requestStatus, setRequestStatus] = useState();
 
   // orders가 유효한 객체인지 확인하고, 아니면 기본값(빈 객체)을 사용
   const data = orders || {};
@@ -15,35 +23,6 @@ const OrderSearchResultTable = ({ orders, searchHandler }) => {
 
   const totalCount =
     data.totalDataCount !== undefined ? data.totalDataCount : orderList.length;
-
-  // const getOrderStatusName = (status) => {
-  //   switch (status) {
-  //     case "PENDING_PAYMENT":
-  //       return "주문접수";
-  //     case "PAID":
-  //       return "결제확인";
-  //     case "PREPARING":
-  //       return "배송준비중";
-  //     case "SHIPPING":
-  //       return "배송중";
-  //     case "DELIVERED":
-  //       return "배송완료";
-  //     case "CANCEL_REQUESTED":
-  //       return "취소 신청";
-  //     case "CANCELED":
-  //       return "취소 완료";
-  //     case "EXCHANGE_REQUESTED":
-  //       return "교환 신청";
-  //     case "EXCHANGED":
-  //       return "교환 완료";
-  //     case "RETURN_REQUESTED":
-  //       return "반품/환불 신청";
-  //     case "RETURNED":
-  //       return "반품/환불 완료";
-  //     default:
-  //       return status; // 정의되지 않은 상태는 그대로 반환
-  //   }
-  // };
 
   const flatOrders = orderList.flatMap((order) => {
     return order.orderProducts.map((op, index) => {
@@ -73,6 +52,15 @@ const OrderSearchResultTable = ({ orders, searchHandler }) => {
   const handleChangeStatus = async (item, value) => {
     if (value == "CONFIRMED")
       return alert("구매확정은 사용자가 할 수 있습니다.");
+    if (value == "RETURN_REQUESTED")
+      return alert("반품/환불 신청은 사용자가 할 수 있습니다.");
+    setConfirmModalData(item);
+    setRequestStatus(value);
+    setIsConfirmModalOpen(true);
+  };
+
+  const handleConfirmChangeStatus = async (item, value) => {
+    // console.log("handleConfirmChangeStatus => ", item, value);
     await changeOrderProductStatus(item.orderId, value);
     await searchHandler();
   };
@@ -202,6 +190,17 @@ const OrderSearchResultTable = ({ orders, searchHandler }) => {
           </tbody>
         </table>
       </div>
+      {isConfirmModalOpen && (
+        <ConfirmModal
+          confirmModalData={confirmModalData}
+          requestStatus={requestStatus}
+          onConfirm={(item, value) => {
+            handleConfirmChangeStatus(item, value);
+            setIsConfirmModalOpen(false);
+          }}
+          onClose={() => setIsConfirmModalOpen(false)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
- 관리자 주문 내역 조회 페이지에서 주문 상태 변경할 때 '해당 주문에 포함된 모든 상품의 주문 상태가 변한다'는 모달창이 뜨도록 함
- 초기화 버튼 누를 시 체크박스 전체 체크 처리되도록 변경