### PR TITLE
[프론트] 주문 상태 집계 기능 수정

### DIFF
--- a/src/api/order/orderApi.js
+++ b/src/api/order/orderApi.js
@@ -49,3 +49,15 @@ export const changeOrderProductStatus = async (orderId, newStatus) => {
   console.log("changeOrderProductStatus => ", res.data);
   return res.data;
 };
+
+export const getOrderStatusSummary = async (userId, startDate, endDate) => {
+  const res = await axiosInstance.get(`${prefix}/summary`, {
+    params: {
+      userId: userId,
+      startDate: startDate,
+      endDate: endDate,
+    },
+  });
+  console.log("getOrderStatusSummary => ", res.data);
+  return res.data;
+};

--- a/src/components/order/OrderComponent.jsx
+++ b/src/components/order/OrderComponent.jsx
@@ -1,21 +1,10 @@
-import axios from "axios";
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
-import {
-  changeOrderProductStatus,
-  deleteOneOrder,
-  getOneOrder,
-  registerOrder,
-} from "../../api/order/orderApi";
-import CouponModal from "./CouponModal";
+import { getOneOrder, registerOrder } from "../../api/order/orderApi";
+import { verifyPaymentAndCompleteOrder } from "../../api/payment/paymentApi";
 import { getActivePoints } from "../../api/point/pointApi";
-import {
-  refundPayment,
-  verifyPaymentAndCompleteOrder,
-} from "../../api/payment/paymentApi";
-
-const API_SERVER_HOST = "http://localhost:8080";
+import CouponModal from "./CouponModal";
 
 // Helper function to format price with commas and '원'
 const formatPrice = (price) => {


### PR DESCRIPTION
- 주문 상태 집계 기능 수정 -> 기존에는 페이지마다 주문 상품의 상태를 집계하였는데 변경 후에는 전체 페이지의 주문 상품의 상태를 집계하도록 변경 -> orderApi에 api 추가(getOrderStatusSummary)
-> OrderHistoryComponent 코드 수정

- OrderComponent 코드 정리