### PR TITLE
[프론트] 제품 목록 스크롤 문제 수정

### DIFF
--- a/src/components/product/ProductListComponent.jsx
+++ b/src/components/product/ProductListComponent.jsx
@@ -193,7 +193,7 @@ const ProductListComponent = () => {
       </aside>
 
       {/* 오른쪽 상품 목록 영역 */}
-      <div className="flex-1 min-w-0">
+      <div className="flex-1 min-w-0 min-h-screen">
         {/* 브레드크럼  */}
         <nav className="flex items-center gap-2 text-sm text-gray-500 mb-6 border-b border-gray-100 pb-4">
           <Link to="/" className="hover:text-gray-700 transition-colors">


### PR DESCRIPTION
제품 수가 적은 페이지에서 스크롤이 끝까지 내려가지 않고 특정 위치로 돌아가는 문제 수정