### PR TITLE
[프론트] 주문 내역 페이지 날짜 오류 수정, 링크 기능 추가

### DIFF
--- a/src/components/orderhistory/OrderHistoryComponent.jsx
+++ b/src/components/orderhistory/OrderHistoryComponent.jsx
@@ -1,6 +1,11 @@
 import { Fragment, useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import {
+  Link,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
 import {
   changeOrderProductStatus,
   confirmOrder,
@@ -523,18 +528,24 @@ export default function OrderHistoryComponent() {
                       )}
 
                       <td className="py-5 px-3">
-                        <div className="w-14 h-14 bg-gray-100 overflow-hidden">
+                        <Link
+                          to={`/product/${item.productId}`}
+                          className="block w-14 h-14 bg-gray-100 overflow-hidden hover:opacity-80 transition-opacity"
+                        >
                           <img
                             src={item.imageUrl}
                             className="w-full h-full object-cover"
                             alt={item.productName}
                           />
-                        </div>
+                        </Link>
                       </td>
                       <td className="py-5 text-left">
-                        <p className="text-sm text-gray-800">
+                        <Link
+                          to={`/product/${item.productId}`}
+                          className="text-sm text-gray-800 hover:underline hover:text-blue-600 transition-colors"
+                        >
                           {item.productName} - {item.productOptionName}
-                        </p>
+                        </Link>
                       </td>
                       <td className="text-center text-gray-700">
                         {item.quantity}


### PR DESCRIPTION
- 주문 내역 페이지 날짜 오류 수정(11월 31일 등 없는 날짜가 날짜 조회에 자동 입력되지 않게 오류 수정함)
- 주문 내역 조회할 때 이미지나 상품명 클릭하면 해당 상품의 상세 페이지로 이동되도록 코드 수정
